### PR TITLE
Fix: Improve mobile header layout and dropdown behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -376,11 +376,12 @@ footer {
     nav ul {
         flex-direction: column;
         padding: 1rem 0;
+        max-height: 70vh;
+        overflow-y: auto;
     }
 
     .dropdown-content {
         position: static;
-        display: block;
         box-shadow: none;
         border: none;
         background: var(--bg-tertiary);


### PR DESCRIPTION
The header navigation on mobile devices, particularly iOS Safari, could previously consume excessive vertical space. This was primarily due to the navigation list expanding to fit all items, including an always-open dropdown menu on smaller screens.

This commit addresses the issue by:
1.  Setting `max-height: 70vh` and `overflow-y: auto` for the `nav ul` element within the `@media (max-width: 768px)` rule. This ensures that the navigation list will not exceed 70% of the viewport height and will become scrollable if its content overflows.
2.  Removing `display: block` from the `.dropdown-content` rule within the same media query. This allows the dropdown to be hidden by default on mobile and only appear on interaction (hover or focus-within the parent), aligning its behavior with larger screens and preventing it from unnecessarily expanding the header.

These changes ensure a more consistent and user-friendly header experience on mobile devices without introducing significant complexity.