### PR TITLE
Fix: Correct path for decision-tree.json in interactive tool

### DIFF
--- a/veterans-preference/tool.js
+++ b/veterans-preference/tool.js
@@ -53,7 +53,7 @@
 
         // Asynchronously fetch the decision tree data.
         try {
-            const response = await fetch('veterans-preference/decision-tree.json');
+            const response = await fetch('decision-tree.json');
             if (!response.ok) {
                 // Handle HTTP errors (e.g., 404 Not Found, 500 Server Error).
                 throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
The interactive tool was unable to load because the fetch request for `decision-tree.json` was using an incorrect path.

This commit updates `veterans-preference/tool.js` to use the correct relative path (`decision-tree.json` instead of `veterans-preference/decision-tree.json`) when fetching the decision tree data. This resolves the initialization error and makes the tool functional.