### PR TITLE
Fix: Prevent nav menu overlap on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -128,7 +128,6 @@ header {
     top: 0;
     z-index: 1000;
     box-shadow: var(--shadow-sm);
-    position: relative; /* For positioning menu toggle */
 }
 
 .header-content {


### PR DESCRIPTION
The main navigation menu items in the header on the Veterans' Preference guide page were wrapping to a second line on smaller screens, but the header was not adjusting its height. This caused the second line of menu items to be obscured by the main content block below it.

This commit addresses the issue by:
1. Correcting the CSS for the `header` element in `style.css`. An erroneous `position: relative;` declaration was overriding the intended `position: sticky;`. This has been removed, ensuring the header behaves as a sticky element.
2. Verifying that no other CSS rules (like fixed heights or `overflow: hidden`) were preventing the `header` or `nav` elements from expanding to accommodate the wrapped content.

With these changes, the header will now correctly adjust its height when navigation items wrap, and the main content will be pushed down appropriately, preventing any overlap. The navigation menu in `veterans-preference/index.html` correctly uses `flex-wrap: wrap` and does not use the hamburger menu styling (as its `ul` lacks the `id="main-nav"`), so its wrapping behavior is preserved and now correctly displayed.