### PR TITLE
Refactor: Remove redundant ARIA roles from landmark elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
     <!-- Header -->
-    <header role="banner">
+    <header>
         <div class="header-content">
             <!-- Modified Title for the new portal -->
             <h1>General Veterans Information Portal</h1>
@@ -30,7 +30,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <nav role="navigation" aria-label="Main navigation">
+        <nav aria-label="Main navigation">
             <ul id="main-nav">
                 <li><a href="index.html" aria-current="page">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
@@ -50,7 +50,7 @@
     </header>
 
     <!-- Main Content -->
-    <main id="main-content" role="main">
+    <main id="main-content">
         <section class="hero">
             <h1>Your Comprehensive Guide to Veterans Information & Resources</h1>
             <p>Find information on benefits, healthcare, education, employment, and more.</p>
@@ -76,7 +76,7 @@
     </main>
 
     <!-- Footer -->
-    <footer role="contentinfo"> <!-- Copied from existing index.html (now veterans-preference-original-index.html) -->
+    <footer> <!-- Copied from existing index.html (now veterans-preference-original-index.html) -->
         <div class="footer-content">
             <div class="footer-section">
                 <h3>Quick Links</h3>


### PR DESCRIPTION
Removed unnecessary `role` attributes (`banner`, `navigation`, `main`, `contentinfo`) from `header`, `nav`, `main`, and `footer` elements in `index.html`.

These roles are implicit in HTML5 and their explicit declaration was causing W3C validation warnings. This change improves code clarity and adherence to web standards without affecting accessibility, as assistive technologies will recognize the default implicit roles.