### PR TITLE
Fix: Make interactive guide menu collapsible on mobile

### DIFF
--- a/veterans-preference/tool-styles.css
+++ b/veterans-preference/tool-styles.css
@@ -249,3 +249,79 @@
         font-size: 0.9rem;
     }
 }
+
+/* Styles for the hamburger menu button */
+.menu-toggle {
+    display: none; /* Hidden by default, shown via media query */
+    background-color: transparent;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 1rem;
+    margin-bottom: 1rem; /* Space below button */
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus {
+    background-color: var(--primary-color-light);
+    color: var(--text-light);
+}
+
+/* Styles for the navigation menu container */
+header nav ul#main-menu {
+    display: flex; /* Default for desktop: flex layout */
+    flex-direction: row;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+/* Mobile-specific styles */
+@media (max-width: 768px) {
+    .menu-toggle {
+        display: block; /* Show the hamburger button on mobile */
+    }
+
+    header nav ul#main-menu {
+        display: none; /* Hide the menu by default on mobile */
+        flex-direction: column; /* Stack links vertically on mobile */
+        width: 100%; /* Take full width */
+        background-color: var(--bg-secondary); /* Optional: background for dropdown */
+        padding: 0.5rem 0; /* Padding for the dropdown */
+    }
+
+    header nav ul#main-menu.is-open {
+        display: flex; /* Show the menu when .is-open class is present */
+    }
+
+    /* Adjust list item styling for mobile dropdown */
+    header nav ul#main-menu li {
+        width: 100%;
+        text-align: left; /* Or center, as per design */
+    }
+
+    header nav ul#main-menu li a {
+        display: block;
+        padding: 0.75rem 1rem; /* Make tap targets larger */
+        border-bottom: 1px solid var(--border-color); /* Separator for links */
+    }
+
+    header nav ul#main-menu li:last-child a {
+        border-bottom: none;
+    }
+
+    /* Ensure dropdowns within the menu also adapt if necessary */
+    header nav ul#main-menu .dropdown-content {
+        position: static; /* Change from absolute to static for mobile flow */
+        box-shadow: none;
+        border: none;
+        background-color: transparent; /* Blend with parent menu background */
+    }
+
+    header nav ul#main-menu .dropdown-content li a {
+        padding-left: 2rem; /* Indent sub-menu items */
+        color: var(--text-secondary); /* Adjust color if needed */
+    }
+}

--- a/veterans-preference/tool.html
+++ b/veterans-preference/tool.html
@@ -24,7 +24,8 @@
             <p class="tagline">Your Unofficial Resource for Federal Employment Benefits</p>
         </div>
         <nav aria-label="Main navigation">
-            <ul>
+            <button class="menu-toggle" aria-expanded="false" aria-controls="main-menu">Menu</button>
+            <ul id="main-menu">
                 <li><a href="../index.html">Home</a></li>
                 <li class="dropdown">
                     <a href="#" aria-haspopup="true" aria-expanded="false">Eligibility</a>

--- a/veterans-preference/tool.js
+++ b/veterans-preference/tool.js
@@ -551,4 +551,28 @@
     } else {
         document.addEventListener('DOMContentLoaded', init);
     }
+
+    // Hamburger menu toggle functionality
+    function setupMenuToggle() {
+        const menuToggleButton = document.querySelector('.menu-toggle');
+        const mainMenu = document.getElementById('main-menu');
+
+        if (menuToggleButton && mainMenu) {
+            menuToggleButton.addEventListener('click', function() {
+                const isExpanded = mainMenu.classList.toggle('is-open');
+                menuToggleButton.setAttribute('aria-expanded', isExpanded);
+                // Optional: Change button text based on state
+                // menuToggleButton.textContent = isExpanded ? 'Close Menu' : 'Menu';
+            });
+        }
+    }
+
+    // Call this function after the main init or ensure DOM is ready.
+    // If init() already handles DOM readiness, integrate this call there,
+    // or ensure it's called appropriately.
+    if (document.readyState === 'interactive' || document.readyState === 'complete') {
+        setupMenuToggle();
+    } else {
+        document.addEventListener('DOMContentLoaded', setupMenuToggle);
+    }
 })();


### PR DESCRIPTION
The main navigation menu in the veterans-preference/tool.html interactive guide was previously not collapsible, taking up significant screen space on mobile devices.

This commit introduces the following changes:

1.  **HTML (`tool.html`):**
    *   I added a hamburger menu button (`.menu-toggle`) to the header.
    *   I wrapped the main navigation `<ul>` in an element with `id="main-menu"` to allow it to be targeted by JavaScript.

2.  **CSS (`tool-styles.css`):**
    *   I added styles to hide the hamburger button on desktop and show it on mobile (<=768px).
    *   I added styles to hide the `ul#main-menu` by default on mobile and display it as a stacked, full-width block when an `.is-open` class is applied.
    *   I ensured existing desktop menu styles are preserved.
    *   I adjusted styles for dropdowns within the menu for better mobile usability.

3.  **JavaScript (`tool.js`):**
    *   I added a `setupMenuToggle` function that attaches an event listener to the hamburger button.
    *   The event listener toggles an `.is-open` class on the `ul#main-menu` element and updates the `aria-expanded` attribute on the button for accessibility.
    *   This script is loaded after the DOM is ready and is placed to avoid conflicts with existing tool logic.

These changes make the menu on the interactive guide page responsive and user-friendly on mobile devices by allowing you to toggle its visibility.