### PR TITLE
Refactor: Standardize CSS selectors and correct minor typo

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/accessibility-statement.html
+++ b/accessibility-statement.html
@@ -31,7 +31,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/all-resources.html
+++ b/all-resources.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/education.html
+++ b/education.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/employment.html
+++ b/employment.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/healthcare.html
+++ b/healthcare.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/housing.html
+++ b/housing.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html" aria-current="page">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -31,7 +31,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/script.js
+++ b/script.js
@@ -51,7 +51,7 @@
     // Enhanced navigation functionality
     function initializeNavigation() {
         const menuToggle = document.querySelector('.menu-toggle');
-        const mainNav = document.getElementById('main-nav'); // Use ID for main nav UL
+        const mainNav = document.querySelector('.main-navigation-menu'); // Use ID for main nav UL
 
         if (menuToggle && mainNav) {
             menuToggle.addEventListener('click', function() {

--- a/state-benefits.html
+++ b/state-benefits.html
@@ -31,7 +31,7 @@
             <span class="icon-bar"></span>
         </button>
         <nav aria-label="Main navigation">
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="veterans-preference/index.html">Veterans' Preference Guide</a></li>
                 <li class="dropdown">

--- a/style.css
+++ b/style.css
@@ -317,14 +317,14 @@ section {
 }
 
 /* Feature Section Specifics */
-section.features {
+.features {
     /* Add horizontal padding to match main's horizontal padding or other sections */
     padding-left: 1rem;
     padding-right: 1rem;
 }
 /* Adjust padding for smaller screens if main's padding also changes */
 @media (max-width: 480px) {
-    section.features {
+    .features {
         padding-left: 0.75rem;
         padding-right: 0.75rem;
     }
@@ -551,7 +551,7 @@ footer {
     /* background-position: center; */
 }
 
-nav ul#main-nav {
+.main-navigation-menu {
     display: none; /* Hide nav by default on mobile */
     position: absolute;
     top: 100%; /* Position below the header */
@@ -571,21 +571,21 @@ nav ul#main-nav {
     align-items: stretch; /* Stretch items to full width */
     }
 
-nav ul#main-nav.nav-open {
+.main-navigation-menu.nav-open {
     display: flex; /* Show nav when class is applied */
     transform: translateY(0);
     opacity: 1;
 }
 
-nav ul#main-nav li {
+.main-navigation-menu li {
     width: 100%;
 }
 
-nav ul#main-nav a {
+.main-navigation-menu a {
     padding: 0.75rem 1.5rem; /* Larger tap targets */
     border-bottom: 1px solid var(--bg-tertiary);
 }
-nav ul#main-nav li:last-child a {
+.main-navigation-menu li:last-child a {
     border-bottom: none;
 }
 
@@ -648,7 +648,7 @@ nav ul#main-nav li:last-child a {
         margin-bottom: 1.5rem; /* Reduced spacing between sections */
     }
 
-    /* section.features padding is already handled by its own @media (max-width: 480px) rule */
+    /* .features padding is already handled by its own @media (max-width: 480px) rule */
 
     /* Hero further refinement */
     .hero {
@@ -692,7 +692,7 @@ nav ul#main-nav li:last-child a {
     h4 { font-size: 0.95rem; }
 
     /* Nav link font size on mobile if needed (already quite large tap targets) */
-    /* nav ul#main-nav a { font-size: 1rem; } */
+    /* .main-navigation-menu a { font-size: 1rem; } */
 
 }
 

--- a/veterans-preference/tool-styles.css
+++ b/veterans-preference/tool-styles.css
@@ -148,7 +148,7 @@
 }
 
 
-.tool-result.eligibile {
+.tool-result.eligible {
     border: 2px solid var(--success-color);
     background: #d4edda;
 }
@@ -270,7 +270,7 @@
 }
 
 /* Styles for the navigation menu container */
-header nav ul#main-menu {
+.tool-main-menu {
     display: flex; /* Default for desktop: flex layout */
     flex-direction: row;
     list-style: none;
@@ -284,7 +284,7 @@ header nav ul#main-menu {
         display: block; /* Show the hamburger button on mobile */
     }
 
-    header nav ul#main-menu {
+    .tool-main-menu {
         display: none; /* Hide the menu by default on mobile */
         flex-direction: column; /* Stack links vertically on mobile */
         width: 100%; /* Take full width */
@@ -292,35 +292,35 @@ header nav ul#main-menu {
         padding: 0.5rem 0; /* Padding for the dropdown */
     }
 
-    header nav ul#main-menu.is-open {
+    .tool-main-menu.is-open {
         display: flex; /* Show the menu when .is-open class is present */
     }
 
     /* Adjust list item styling for mobile dropdown */
-    header nav ul#main-menu li {
+    .tool-main-menu li {
         width: 100%;
         text-align: left; /* Or center, as per design */
     }
 
-    header nav ul#main-menu li a {
+    .tool-main-menu li a {
         display: block;
         padding: 0.75rem 1rem; /* Make tap targets larger */
         border-bottom: 1px solid var(--border-color); /* Separator for links */
     }
 
-    header nav ul#main-menu li:last-child a {
+    .tool-main-menu li:last-child a {
         border-bottom: none;
     }
 
     /* Ensure dropdowns within the menu also adapt if necessary */
-    header nav ul#main-menu .dropdown-content {
+    .tool-main-menu .dropdown-content {
         position: static; /* Change from absolute to static for mobile flow */
         box-shadow: none;
         border: none;
         background-color: transparent; /* Blend with parent menu background */
     }
 
-    header nav ul#main-menu .dropdown-content li a {
+    .tool-main-menu .dropdown-content li a {
         padding-left: 2rem; /* Indent sub-menu items */
         color: var(--text-secondary); /* Adjust color if needed */
     }

--- a/veterans-preference/tool.html
+++ b/veterans-preference/tool.html
@@ -30,7 +30,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <ul id="main-nav">
+            <ul class="main-navigation-menu">
                 <li><a href="../index.html">Home</a></li>
                 <li class="dropdown">
                     <a href="#" aria-haspopup="true" aria-expanded="false">Eligibility</a>

--- a/veterans-preference/tool.js
+++ b/veterans-preference/tool.js
@@ -556,7 +556,7 @@
 /*
     function setupMenuToggle() {
         const menuToggleButton = document.querySelector('.menu-toggle');
-        const mainMenu = document.getElementById('main-menu');
+        const mainMenu = document.querySelector('.tool-main-menu');
 
         if (menuToggleButton && mainMenu) {
             menuToggleButton.addEventListener('click', function() {


### PR DESCRIPTION
- I replaced ID-based selectors (#main-nav, #main-menu) with class-based selectors (.main-navigation-menu, .tool-main-menu) in CSS, HTML, and JavaScript for improved reusability.
- I simplified several CSS selectors by removing redundant tag qualifiers where class names were sufficiently specific (e.g., `nav ul.main-navigation-menu` to `.main-navigation-menu`).
- I corrected a typo in `veterans-preference/tool-styles.css` from `.tool-result.eligibile` to `.tool-result.eligible`.
- These changes focus on improving CSS manageability and follow the guideline of favoring class-based selectors without large-scale refactoring.