### PR TITLE
Fix: Resolve mobile menu visibility issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -184,6 +184,10 @@ nav a[aria-current="page"] {
     color: var(--primary-color);
 }
 
+#navigation-placeholder > nav {
+    position: relative;
+}
+
 /* Menu Toggle Button (Hamburger) */
 .menu-toggle {
     display: none; /* Hidden by default, shown in media query */
@@ -566,7 +570,7 @@ footer {
     transition: transform var(--transition-normal), opacity var(--transition-normal);
     transform: translateY(-10px); /* Start slightly above for transition */
     opacity: 0;
-    z-index: 1000; /* Ensure it's above content but below sticky header if toggle is outside */
+    z-index: 1005; /* Ensure it's above content but below sticky header if toggle is outside */
     flex-direction: column; /* Stack items vertically */
     align-items: stretch; /* Stretch items to full width */
     }


### PR DESCRIPTION
The mobile hamburger menu was not displaying its items after being clicked, although the icon itself changed state. This was due to two issues:

1. The absolutely positioned mobile navigation menu (`.main-navigation-menu`) lacked a proper positioning context. Its `top: 100%` style was likely being interpreted relative to the body or another distant ancestor, pushing it off-screen.
   - Solution: I added `position: relative;` to the parent `nav` element (specifically `#navigation-placeholder > nav`) to correctly anchor the mobile menu.

2. The mobile menu had the same `z-index` (1000) as the sticky header. While the positioning fix was primary, as a precaution, I slightly increased the menu's `z-index`.
   - Solution: I increased the `z-index` of `.main-navigation-menu` to `1005` in mobile view to ensure it renders above the sticky header in all stacking scenarios.

These changes ensure the mobile navigation menu now appears correctly below the header when activated.