### PR TITLE
Fix: Ensure hamburger menu functions on tool.html

### DIFF
--- a/veterans-preference/tool.html
+++ b/veterans-preference/tool.html
@@ -17,54 +17,8 @@
 <body>
     <a href="#tool-content" class="skip-link">Skip to assessment tool</a>
 
-    <!-- Header reused from index.html -->
-    <header>
-        <div class="header-content">
-            <h1>Veterans' Preference Guide</h1>
-            <p class="tagline">Your Unofficial Resource for Federal Employment Benefits</p>
-        </div>
-        <nav aria-label="Main navigation">
-            <button class="menu-toggle" aria-expanded="false" aria-controls="main-nav">
-                <span class="visually-hidden">Menu</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-            <ul class="main-navigation-menu">
-                <li><a href="../index.html">Home</a></li>
-                <li class="dropdown">
-                    <a href="#" aria-haspopup="true" aria-expanded="false">Eligibility</a>
-                    <ul class="dropdown-content">
-                        <li><a href="content/eligibility/basic-requirements.html">Basic Requirements</a></li>
-                        <li><a href="content/eligibility/character-of-discharge.html">Character of Discharge</a></li>
-                        <li><a href="content/eligibility/documentation.html">Required Documents</a></li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" aria-haspopup="true" aria-expanded="false">Preference Types</a>
-                    <ul class="dropdown-content">
-                        <li><a href="content/preference-types/5-point.html">5-Point Preference</a></li>
-                        <li><a href="content/preference-types/10-point.html">10-Point Preference</a></li>
-                        <li><a href="content/preference-types/derivative.html">Derivative Preference</a></li>
-                    </ul>
-                </li>
-                <li><a href="content/rif-procedures/index.html">RIF Procedures</a></li>
-                <li><a href="content/special-authorities/index.html">Special Appointing Authorities</a></li>
-                <li class="dropdown">
-                    <a href="content/appendices/index.html" aria-haspopup="true" aria-expanded="false">Appendices</a>
-                    <ul class="dropdown-content">
-                        <li><a href="content/appendices/appendix-a.html">Appendix A: Campaigns</a></li>
-                        <li><a href="content/appendices/appendix-b.html">Appendix B: Service Types</a></li>
-                        <li><a href="content/appendices/appendix-c.html">Appendix C: Officer Ranks</a></li>
-                        <li><a href="content/appendices/appendix-d.html">Appendix D: History</a></li>
-                    </ul>
-                </li>
-                <li><a href="tool.html" aria-current="page">Interactive Guide</a></li>
-                <li><a href="content/faq.html">FAQ</a></li>
-            </ul>
-        </nav>
-    </header>
-    <!-- End of reused header -->
+   <div id="header-placeholder"></div>
+   <div id="navigation-placeholder"></div>
 
     <main id="tool-content">
         <div class="tool-container">


### PR DESCRIPTION
I refactored `veterans-preference/tool.html` to use the standard JavaScript-driven header and navigation placeholders (`#header-placeholder`, `#navigation-placeholder`).

This change ensures that the hamburger menu JavaScript in `script.js`, which targets elements within these placeholders, can now correctly initialize and operate the menu on `tool.html`.

This also aligns `tool.html` with the site-wide strategy of using JavaScript includes for common elements like the header and navigation, reducing code duplication.