### PR TITLE
Fix: Prevent script halt in accessibility initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -237,8 +237,19 @@
         announcer.setAttribute('role', 'status');
         announcer.setAttribute('aria-live', 'polite');
         announcer.setAttribute('aria-atomic', 'true');
-        announcer.className = config.CSS_CLASSES.SCREEN_READER_ONLY; // Use config for class name
-        document.body.appendChild(announcer);
+
+        if (config && config.CSS_CLASSES && typeof config.CSS_CLASSES.SCREEN_READER_ONLY === 'string') {
+            announcer.className = config.CSS_CLASSES.SCREEN_READER_ONLY;
+        } else {
+            announcer.className = 'sr-only'; // Default class if config is missing
+            console.warn('Config issue: config.CSS_CLASSES.SCREEN_READER_ONLY is not defined. Using default "sr-only".');
+        }
+        // Ensure document.body exists before appending. Should be true within DOMContentLoaded.
+        if (document.body) {
+            document.body.appendChild(announcer);
+        } else {
+            console.error('document.body is not available when trying to append screen reader announcer.');
+        }
     }
 
     function checkAccessibleLabels(config) {


### PR DESCRIPTION
This commit addresses an issue where the site was loading as plain text after the initial JavaScript modularization effort.

The root cause was identified as a potential TypeError in `initScreenReaderAnnouncer` within `script.js` if certain `config` properties were undefined. This error would halt script execution before critical HTML snippets (header, navigation, footer) could be loaded.

The fix makes `initScreenReaderAnnouncer` more resilient by:
- Checking for the existence of `config.CSS_CLASSES.SCREEN_READER_ONLY` before use.
- Using a default class name (`'sr-only'`) and logging a console warning if the configured class name is not found.
- Adding a check for `document.body` before appending elements.

This ensures that `initializeAccessibility` does not halt script execution, allowing `loadHTMLSnippetsAndInitializeNav` to run and correctly render the page structure.

The original modularization of `script.js` and `veterans-preference/tool.js` remains, now with this critical fix.