### PR TITLE
Configure Jekyll for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+gem "jekyll", "~> 4.2" # Or the version GitHub Pages uses
+gem "jekyll-theme-minimal"
+# Add other jekyll plugins GitHub Pages supports if needed (e.g., jekyll-sitemap, jekyll-seo-tag)
+group :jekyll_plugins do
+  gem "jekyll-sitemap"
+  gem "jekyll-seo-tag"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,25 @@
+title: General Veterans Information Portal
+description: Your comprehensive guide to veterans information on benefits, healthcare, education, employment, and more.
 theme: jekyll-theme-minimal
+url: "https://veterans-info.github.io" # Your GitHub Pages URL
+baseurl: "" # Usually empty for project pages, or /repo-name for user/org pages
+
+# Optional: Add default front matter for pages/collections
+defaults:
+  - scope:
+      path: ""
+      type: "pages" # This will apply to all .md files that are not posts or in collections
+    values:
+      layout: "page"
+  - scope:
+      path: ""
+      type: "appendices" # Assuming 'appendices' is the collection name
+    values:
+      layout: "collection_item"
+      # Add other defaults like category if needed
+
+# Collections setup
+collections:
+  appendices:
+    output: true
+    permalink: /veterans-preference/appendices/:path/


### PR DESCRIPTION
This commit introduces the initial Jekyll configuration for your site.

- Updates `_config.yml` with site title, description, theme (jekyll-theme-minimal), URL, baseurl, and default front matter for pages and collections. Sets up a collection for 'appendices'.
- Creates `Gemfile` specifying Jekyll version, the minimal theme, and essential plugins like jekyll-sitemap and jekyll-seo-tag.
- Updates `.gitignore` to include common Jekyll-generated files and directories such as `_site/`, `.sass-cache/`, `.jekyll-cache/`, `.jekyll-metadata`, and `Gemfile.lock`.

These changes establish the foundational setup for building and deploying your site with Jekyll on GitHub Pages.