### PR TITLE
Complete Jekyll includes and static assets setup

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,0 +1,7 @@
+<nav aria-label="Breadcrumb" class="usa-breadcrumb">
+  <ol class="usa-breadcrumb__list">
+    <li class="usa-breadcrumb__list-item">
+      <span>Breadcrumbs will go here.</span>
+    </li>
+  </ol>
+</nav>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,30 @@
+<footer class="usa-footer usa-footer--slim">
+  <div class="grid-container usa-footer__return-to-top">
+    <a href="#">Return to top</a>
+  </div>
+  <div class="usa-footer__primary-section">
+    <div class="usa-footer__primary-container grid-row">
+      <div class="mobile-lg:grid-col-8">
+        <nav class="usa-footer__nav" aria-label="Footer navigation">
+          <ul class="grid-row grid-gap">
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <p>Quick links will go here</p>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <div class="usa-footer__secondary-section">
+    <div class="grid-container">
+      <div class="usa-footer__logo grid-row grid-gap-2">
+        <div class="grid-col-auto">
+          <p>&copy; 2025 OPM</p>
+        </div>
+        <div class="grid-col-auto">
+          <p>On June 26, 2013, the Supreme Court ruled that Section 3 of the Defense of Marriage Act (DOMA) is unconstitutional. As a result of the Supreme Court’s decision, the United States Office of Personnel Management (OPM) will now be able to extend certain benefits to Federal employees and annuitants who have legally married a spouse of the same sex, regardless of the employee’s or annuitant’s state of residency. OPM is currently in the process of updating and revising the website to reflect this change, and will be updating this information as soon as possible. Please check back in the coming weeks for updates.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,27 @@
+<header class="usa-header usa-header--basic">
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <div class="usa-logo" id="basic-logo">
+        <em class="usa-logo__text">
+          <a href="{{ "/" | relative_url }}" title="Home" aria-label="Home">
+            <img src="{{ '/assets/images/logo.svg' | relative_url }}" alt="Site Logo" style="height: 32px; width: 32px; margin-right: 5px;">
+            VET GUIDE FOR HR PROFESSIONALS
+          </a>
+        </em>
+      </div>
+      <button class="usa-menu-btn">Menu</button>
+    </div>
+    <nav aria-label="Primary navigation" class="usa-nav">
+      {% include navigation.html %}
+    </nav>
+  </div>
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner__header">
+        <div class="usa-banner__inner">
+          <p>OPM.gov / Policy / Veterans Services / Vet Guide for HR Professionals</p>
+        </div>
+      </header>
+    </div>
+  </div>
+</header>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,0 +1,5 @@
+<ul class="usa-nav__primary usa-accordion">
+  <li class="usa-nav__primary-item">
+    <a class="usa-nav__link" href="{{ "/" | relative_url }}"><span>Home</span></a>
+  </li>
+</ul>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,4 +1,7 @@
 ---
+# Only an empty front matter is required for SCSS processing
 ---
 
-@import "main";
+@import "{{ site.theme }}";
+
+// Your custom styles/overrides will go here


### PR DESCRIPTION
This commit addresses issue #<issue_number> (replace with actual issue number if available).

Changes include:

- Updated `_includes/header.html`: Added site title ("VET GUIDE FOR HR PROFESSIONALS"), tagline ("OPM.gov / Policy / Veterans Services / Vet Guide for HR Professionals"), logo path, and navigation include.
- Updated `_includes/footer.html`: Added copyright notice (© 2025 OPM), placeholder quick links, and disclaimer text from hrdocs.txt.
- Updated `_includes/navigation.html`: Initialized with a basic "Home" link.
- Updated `_includes/breadcrumb.html`: Added placeholder text "Breadcrumbs will go here." with basic USWDS styling.
- Updated `assets/css/style.scss`: Ensured correct front matter, added `@import "{{ site.theme }}";`, and a placeholder for custom styles.
- Verified existence of `assets/images/logo.svg` and `assets/images/favicon.svg`.