### PR TITLE
feat: Complete Phase 1 of website development

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,7 +1,13 @@
 <nav aria-label="Breadcrumb" class="usa-breadcrumb">
   <ol class="usa-breadcrumb__list">
     <li class="usa-breadcrumb__list-item">
-      <span>Breadcrumbs will go here.</span>
+      <a href="{{ "/" | relative_url }}" class="usa-breadcrumb__link">Home</a>
     </li>
+    <!-- Additional breadcrumb items will be added dynamically by Jekyll or JavaScript -->
+    {% if page.url != "/" %}
+    <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+      <span>{{ page.title }}</span>
+    </li>
+    {% endif %}
   </ol>
 </nav>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,16 @@
         <nav class="usa-footer__nav" aria-label="Footer navigation">
           <ul class="grid-row grid-gap">
             <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-              <p>Quick links will go here</p>
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Quick Link 1</a>
+            </li>
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Quick Link 2</a>
+            </li>
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Quick Link 3</a>
+            </li>
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+              <a class="usa-footer__primary-link" href="javascript:void(0);">Quick Link 4</a>
             </li>
           </ul>
         </nav>
@@ -19,7 +28,7 @@
     <div class="grid-container">
       <div class="usa-footer__logo grid-row grid-gap-2">
         <div class="grid-col-auto">
-          <p>&copy; 2025 OPM</p>
+          <p>&copy; {% assign current_year = 'now' | date: "%Y" %}{{ current_year }} OPM</p>
         </div>
         <div class="grid-col-auto">
           <p>On June 26, 2013, the Supreme Court ruled that Section 3 of the Defense of Marriage Act (DOMA) is unconstitutional. As a result of the Supreme Court’s decision, the United States Office of Personnel Management (OPM) will now be able to extend certain benefits to Federal employees and annuitants who have legally married a spouse of the same sex, regardless of the employee’s or annuitant’s state of residency. OPM is currently in the process of updating and revising the website to reflect this change, and will be updating this information as soon as possible. Please check back in the coming weeks for updates.</p>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -2,4 +2,32 @@
   <li class="usa-nav__primary-item">
     <a class="usa-nav__link" href="{{ "/" | relative_url }}"><span>Home</span></a>
   </li>
+  <li class="usa-nav__primary-item">
+    <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="nav-section-one">
+      <span>Veterans' Preference</span>
+    </button>
+    <ul id="nav-section-one" class="usa-nav__submenu">
+      <li class="usa-nav__submenu-item">
+        <a href="{{ '/preference-in-appointments' | relative_url }}">Preference in Appointments</a>
+      </li>
+      <li class="usa-nav__submenu-item">
+        <a href="{{ '/preference-in-rif' | relative_url }}">Preference in Reduction in Force</a>
+      </li>
+    </ul>
+  </li>
+  <li class="usa-nav__primary-item">
+    <a class="usa-nav__link" href="{{ '/special-appointing-authorities' | relative_url }}"><span>Special Appointing Authorities</span></a>
+  </li>
+  <li class="usa-nav__primary-item">
+    <a class="usa-nav__link" href="{{ '/restoration-after-uniformed-service' | relative_url }}"><span>Restoration after Uniformed Service</span></a>
+  </li>
+  <li class="usa-nav__primary-item">
+    <a class="usa-nav__link" href="{{ '/special-redress-and-appeals' | relative_url }}"><span>Special Redress And Appeals</span></a>
+  </li>
+  <li class="usa-nav__primary-item">
+    <a class="usa-nav__link" href="{{ '/miscellaneous-provisions' | relative_url }}"><span>Miscellaneous Provisions</span></a>
+  </li>
+  <li class="usa-nav__primary-item">
+    <a class="usa-nav__link" href="{{ "/appendices/" | relative_url }}"><span>Appendices</span></a>
+  </li>
 </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,56 +1,20 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
-  <head>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-{% seo %}
-    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
-    <!--[if lt IE 9]>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
-    <![endif]-->
-    {% include head-custom.html %}
-  </head>
-  <body>
-    <div class="wrapper">
-      <header>
-        <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-
-        {% if site.logo %}
-          <img src="{{site.logo | relative_url}}" alt="Logo" />
-        {% endif %}
-
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
-
-        {% if site.github.is_project_page %}
-        <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
-        {% endif %}
-
-        {% if site.github.is_user_page %}
-        <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
-        {% endif %}
-
-        {% if site.show_downloads %}
-        <ul class="downloads">
-          <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
-          <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
-        </ul>
-        {% endif %}
-      </header>
-      <section>
-
-      {{ content }}
-
-      </section>
-      <footer>
-        {% if site.github.is_project_page %}
-        <p>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
-        {% endif %}
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
-      </footer>
-    </div>
-    <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
-  </body>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% seo %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    <link rel="icon" type="image/svg+xml" href="{{ '/assets/images/favicon.svg' | relative_url }}">
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+</head>
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    {% include header.html %}
+    <main id="main-content" role="main">
+        {{ content }}
+    </main>
+    {% include footer.html %}
+    <script src="{{ '/assets/js/script.js' | relative_url }}" defer></script>
+</body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,7 +7,7 @@ layout: default
     {{ content }}
     {% if page.source_citation %}
     <aside class="citation">
-        <h3>Source</h3>
+        <h3>Source Reference</h3>
         <p>{{ page.source_citation }}</p>
     </aside>
     {% endif %}


### PR DESCRIPTION
This commit implements the basic Jekyll layouts, includes, and root page structures as outlined in Phase 1 of the project.

The following files were created or updated:
- _layouts/default.html: Base HTML structure for all pages.
- _layouts/page.html: Layout for standard content pages.
- _includes/header.html: Site header with title, logo, and navigation.
- _includes/footer.html: Site footer with copyright, quick links, and disclaimer.
- _includes/navigation.html: Main site navigation structure.
- _includes/breadcrumb.html: Placeholder for breadcrumb navigation.

Content for header and footer elements was sourced from hrdocs.txt as specified. Navigation links were created based on the main sections identified in hrdocs.txt.