### PR TITLE
feat: Populate core guide content pages from hrdocs

### DIFF
--- a/eligibility.md
+++ b/eligibility.md
@@ -1,46 +1,57 @@
 ---
 layout: page
-title: Eligibility Requirements
+title: Eligibility
 permalink: /eligibility/
 ---
 
-## Why Preference is Given
-Since the time of the Civil War, veterans of the Armed Forces have been given some degree of preference in
-appointments to Federal jobs. Recognizing their sacrifice, Congress enacted laws to prevent veterans seeking
-Federal employment from being penalized for their time in military service. Veterans' preference recognizes
-the economic loss suffered by citizens who have served their country in uniform, restores veterans to a
-favorable competitive position for Government employment, and acknowledges the larger obligation owed to
-disabled veterans.
-Veterans' preference in its present form comes from the Veterans' Preference Act of 1944, as amended, and is
-now codified in various provisions of title 5, United States Code. By law, veterans who are disabled or who
-served on active duty in the Armed Forces during certain specified time periods or in military campaigns are
-entitled to preference over others in hiring from competitive lists of eligibles and also in retention during
-reductions in force.
-In addition to receiving preference in competitive appointments, veterans may be considered for special
-noncompetitive appointments for which only they are eligible. See Chapter 4.
-
 ## When Preference Applies
-Preference in hiring applies to permanent and temporary positions in the competitive and excepted services
-of the executive branch. Preference does not apply to positions in the Senior Executive Service or to
-executive branch positions for which Senate confirmation is required. The legislative and judicial branches of
-the Federal Government also are exempt from the Veterans' Preference Act unless the positions are in the
-competitive service (Government Printing Office, for example) or have been made subject to the Act by
-another law.
-Preference applies in hiring from civil service examinations conducted by the Office of Personnel
-Management (OPM) and agencies under delegated examining authority, for most excepted service jobs
-including Veterans Recruitment Appointments (VRA), and when agencies make temporary, term, and
-overseas limited appointments. Veterans' preference does not apply to promotion, reassignment, change to
-lower grade, transfer or reinstatement.
-Veterans' preference does not require an agency to use any particular appointment process. Agencies have
-broad authority under law to hire from any appropriate source of eligibles including special appointing
-authorities. An agency may consider candidates already in the civil service from an agency-developed merit
-promotion list or it may reassign a current employee, transfer an employee from another agency, or reinstate
-a former Federal employee. In addition, agencies are required to give priority to displaced employees before
-using civil service examinations and similar hiring methods.
-Civil service examination: 5 U.S.C. 3304-3330, 5 CFR Part 332, OPM Delegation Agreements
-with individual agencies, OPM Examining Handbook, OPM Delegated Examining Operations
-Handbook; Excepted service appointments, including VRA's: 5 U.S.C. 3320; 5 CFR Part 302;
-Temporary and term employment: 5 CFR Parts 316 and 333; Overseas limited employment:
-5 CFR Part 301; Career Transition Program: 5 CFR Part 330, Subparts F and G.
 
-Based on the OPM Vet Guide for HR Professionals (Chapter: Veterans' Preference in Appointments).
+Preference in hiring applies to permanent and temporary positions in the competitive and excepted services of the executive branch. Preference does not apply to positions in the Senior Executive Service or to executive branch positions for which Senate confirmation is required. The legislative and judicial branches of the Federal Government also are exempt from the Veterans' Preference Act unless the positions are in the competitive service (Government Printing Office, for example) or have been made subject to the Act by another law.
+
+Preference applies in hiring from civil service examinations conducted by the Office of Personnel Management (OPM) and agencies under delegated examining authority, for most excepted service jobs including Veterans Recruitment Appointments (VRA), and when agencies make temporary, term, and overseas limited appointments. Veterans' preference does not apply to promotion, reassignment, change to lower grade, transfer or reinstatement.
+
+Veterans' preference does not require an agency to use any particular appointment process. Agencies have broad authority under law to hire from any appropriate source of eligibles including special appointing authorities. An agency may consider candidates already in the civil service from an agency-developed merit promotion list or it may reassign a current employee, transfer an employee from another agency, or reinstate a former Federal employee. In addition, agencies are required to give priority to displaced employees before using civil service examinations and similar hiring methods.
+
+Civil service examination: 5 U.S.C. 3304-3330, 5 CFR Part 332, OPM Delegation Agreements with individual agencies, OPM Examining Handbook, OPM Delegated Examining Operations Handbook; Excepted service appointments, including VRA's: 5 U.S.C. 3320; 5 CFR Part 302; Temporary and term employment: 5 CFR Parts 316 and 333; Overseas limited employment: 5 CFR Part 301; Career Transition Program: 5 CFR Part 330, Subparts F and G.
+
+## Types of Preference
+
+To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions (i.e., with an honorable or general discharge). As defined in 5 U.S.C. 2101(2), "Armed Forces" means the Army, Navy, Air Force, Marine Corps and Coast Guard. The veteran must also be eligible under one of the preference categories below (also shown on the Standard Form (SF) 50, Notification of Personnel Action).
+
+Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)
+
+For non-disabled users, active duty for training by National Guard or Reserve soldiers does not qualify as "active duty" for preference.
+
+For disabled veterans, active duty includes training service in the Reserves or National Guard, per the Merit Systems Protection Board decision in Hesse v. Department of the Army, 104 M.S.P.R.647(2007).
+
+For purposes of this chapter and 5 U.S.C. 2108, "war" means only those armed conflicts declared by Congress as war and includes World War II, which covers the period from December 7, 1941, to April 28, 1952.
+
+When applying for Federal jobs, eligible veterans should claim preference on their application or resume. Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation.
+
+The following preference categories and points are based on 5 U.S.C. 2108 and 3309 as modified by a length of service requirement in 38 U.S.C. 5303A(d).
+
+## Adjudication of Veterans' Preference Claims
+
+Agencies are responsible for adjudicating all preference claims except claims for preference based on common-law marriage, which should be sent to the Office of Personnel Management (OPM), Office of the General Counsel, 1900 E. St. NW, Washington, DC 20415.
+
+5 U.S.C. 3309, 3313 and 5 CFR 332.401, 337.101
+
+## Crediting Experience of Preference Eligibles
+
+In evaluating experience, an examining office must credit a preference eligible's Armed Forces service as an extension of the work performed immediately prior to the service, or on the basis of the actual duties performed in the service, or as a combination of both, whichever would most benefit the preference eligible. The examining office must also give all applicants credit for job-related experience, paid and unpaid, including experience in religious, civic, welfare, service and organizational activities.
+
+5 U.S.C. 3311, 5 CFR 337.101
+
+## Physical Qualifications
+
+In determining qualifications, agencies must waive a medical standard or physical requirement when there is sufficient evidence that the employee or applicant, with or without reasonable accommodation, can perform the essential duties of the position without endangering the health and safety of the individual or others. Special provisions apply to the proposed disqualification of a preference eligible with a 30 percent or more compensable disability. See Disqualification of 30 Percent or more Disabled Veterans below.
+
+5 U.S.C. 3312, 5 CFR Part 339.204
+
+## Age Qualifications
+
+On July 2, 2008, the Merit Systems Protection Board (Board) issued a final decision in Robert P. Isabella v. Department of State and Office of Personnel Management, 2008 M.S.P.B. 146, that affects preference eligibles who apply for federal positions having a maximum entry-age restriction. The Board decided that the agency's failure to waive the maximum entry-age requirements for Mr. Isabella, a preference eligible veteran, violated his rights under the Veteran Employment Opportunities Act of 1998 (VEOA) because there was no demonstration that a maximum entry-age was essential to the performance of the position.
+
+Based on the Board's decision in Isabella, qualified preference eligibles may now apply and be considered for vacancies regardless of whether they meet the maximum age requirements identified at 5 U.S.C. 3307. In order to determine whether it must waive a maximum entry-age requirement, an agency must first analyze the affected position to determine whether age is essential to the performance of the position. If the agency decides age is not essential to the position, then it must waive the maximum entry-age requirement for veterans' preference eligible applicants. In instances where the maximum entry-age is waived, the corresponding mandatory retirement age for these individuals will also be higher because it will be reached after 20 years of Law Enforcement Officer (LEO) service for the entitlement to an immediate enhanced annuity.
+
+The same principles set forth above would apply to appointments to other types of positions for which the setting of maximum entry ages are authorized under 5 U.S.C. § 3307. These types of positions are: (1) firefighters, (2) air traffic controllers, (3) United States Park police, (4) nuclear materials couriers, and (5) customs and border patrol officers (subject to the Federal Employees Retirement System, 5 U.S.C. § 8401 et seq. only).

--- a/eligibility_content.txt
+++ b/eligibility_content.txt
@@ -1,0 +1,89 @@
+When Preference Applies
+Preference in hiring applies to permanent and temporary positions in the competitive and excepted services
+of the executive branch. Preference does not apply to positions in the Senior Executive Service or to
+executive branch positions for which Senate confirmation is required. The legislative and judicial branches of
+the Federal Government also are exempt from the Veterans' Preference Act unless the positions are in the
+competitive service (Government Printing Office, for example) or have been made subject to the Act by
+another law.
+Preference applies in hiring from civil service examinations conducted by the Office of Personnel
+Management (OPM) and agencies under delegated examining authority, for most excepted service jobs
+including Veterans Recruitment Appointments (VRA), and when agencies make temporary, term, and
+overseas limited appointments. Veterans' preference does not apply to promotion, reassignment, change to
+lower grade, transfer or reinstatement.
+Veterans' preference does not require an agency to use any particular appointment process. Agencies have
+broad authority under law to hire from any appropriate source of eligibles including special appointing
+authorities. An agency may consider candidates already in the civil service from an agency-developed merit
+promotion list or it may reassign a current employee, transfer an employee from another agency, or reinstate
+a former Federal employee. In addition, agencies are required to give priority to displaced employees before
+using civil service examinations and similar hiring methods.
+Civil service examination: 5 U.S.C. 3304-3330, 5 CFR Part 332, OPM Delegation Agreements
+with individual agencies, OPM Examining Handbook, OPM Delegated Examining Operations
+Handbook; Excepted service appointments, including VRA's: 5 U.S.C. 3320; 5 CFR Part 302;
+Temporary and term employment: 5 CFR Parts 316 and 333; Overseas limited employment:
+5 CFR Part 301; Career Transition Program: 5 CFR Part 330, Subparts F and G.
+
+Types of Preference
+To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces
+under honorable conditions (i.e., with an honorable or general discharge). As defined in 5 U.S.C. 2101(2),
+"Armed Forces" means the Army, Navy, Air Force, Marine Corps and Coast Guard. The veteran must also be
+eligible under one of the preference categories below (also shown on the Standard Form (SF) 50,
+Notification of Personnel Action).
+Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in
+appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing
+military retired pay until age 60.)
+For non-disabled users, active duty for training by National Guard or Reserve soldiers does not qualify as
+"active duty" for preference.
+For disabled veterans, active duty includes training service in the Reserves or National Guard, per the Merit
+Systems Protection Board decision in Hesse v. Department of the Army, 104 M.S.P.R.647(2007).
+For purposes of this chapter and 5 U.S.C. 2108, "war" means only those armed conflicts declared by
+Congress as war and includes World War II, which covers the period from December 7, 1941, to April 28,
+1952.
+When applying for Federal jobs, eligible veterans should claim preference on their application or resume.
+Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point
+Veteran Preference, and submit the requested documentation.
+The following preference categories and points are based on 5 U.S.C. 2108 and 3309 as modified by a length
+of service requirement in 38 U.S.C. 5303A(d).
+
+Adjudication of Veterans' Preference Claims
+Agencies are responsible for adjudicating all preference claims except claims for preference based on
+common-law marriage, which should be sent to the Office of Personnel Management (OPM), Office of the
+General Counsel, 1900 E. St. NW, Washington, DC 20415.
+5 U.S.C. 3309, 3313 and 5 CFR 332.401, 337.101
+
+Crediting Experience of Preference Eligibles
+In evaluating experience, an examining office must credit a preference eligible's Armed Forces service as an
+extension of the work performed immediately prior to the service, or on the basis of the actual duties
+performed in the service, or as a combination of both, whichever would most benefit the preference eligible.
+The examining office must also give all applicants credit for job-related experience, paid and unpaid,
+including experience in religious, civic, welfare, service and organizational activities.
+5 U.S.C. 3311, 5 CFR 337.101
+
+Physical Qualifications
+In determining qualifications, agencies must waive a medical standard or physical requirement when there is
+sufficient evidence that the employee or applicant, with or without reasonable accommodation, can perform
+the essential duties of the position without endangering the health and safety of the individual or others.
+Special provisions apply to the proposed disqualification of a preference eligible with a 30 percent or more
+compensable disability. See Disqualification of 30 Percent or more Disabled Veterans below. 5 U.S.C.
+3312, 5 CFR Part 339.204
+
+Age Qualifications
+On July 2, 2008, the Merit Systems Protection Board (Board) issued a final decision in Robert P. Isabella v.
+Department of State and Office of Personnel Management, 2008 M.S.P.B. 146, that affects preference
+eligibles who apply for federal positions having a maximum entry-age restriction. The Board decided that the
+agency's failure to waive the maximum entry-age requirements for Mr. Isabella, a preference eligible veteran,
+violated his rights under the Veteran Employment Opportunities Act of 1998 (VEOA) because there was no
+demonstration that a maximum entry-age was essential to the performance of the position.
+Based on the Board's decision in Isabella, qualified preference eligibles may now apply and be considered for
+vacancies regardless of whether they meet the maximum age requirements identified at 5 U.S.C. 3307. In
+order to determine whether it must waive a maximum entry-age requirement, an agency must first analyze
+the affected position to determine whether age is essential to the performance of the position. If the agency
+decides age is not essential to the position, then it must waive the maximum entry-age requirement for
+veterans' preference eligible applicants. In instances where the maximum entry-age is waived, the
+corresponding mandatory retirement age for these individuals will also be higher because it will be reached
+after 20 years of Law Enforcement Officer (LEO) service for the entitlement to an immediate enhanced
+annuity.
+The same principles set forth above would apply to appointments to other types of positions for which the
+setting of maximum entry ages are authorized under 5 U.S.C. § 3307. These types of positions are: (1)
+firefighters, (2) air traffic controllers, (3) United States Park police, (4) nuclear materials couriers, and (5)
+customs and border patrol officers (subject to the Federal Employees Retirement System, 5 U.S.C. § 8401 et
+seq. only).

--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,116 @@
+---
+layout: page
+title: Frequently Asked Questions
+permalink: /faq/
+---
+
+## Questions and Answers about Gulf War Preference
+
+**Public Law 105-85 of November 18, 1997, contains a provision (section 1102 of Title XI) which accords Veterans' preference to anyone who served on active duty, anywhere in the world, for any length of time between August 2, 1990, and January 2, 1992, provided the person is "otherwise eligible." What does "otherwise eligible" mean, here?**
+
+It means the person must have been separated from the service under honorable conditions and have served continuously for a minimum of 24 months or the full period for which called or ordered to active duty. For example, someone who enlisted in the Army and was serving on active duty when the Gulf War broke out on Aug 2, 1990, would have to complete a minimum of 24 months service to be eligible for preference. On the other hand a Reservist who was called to active duty for a month and spent all his time at the Pentagon before being released would also be eligible. What the law did was to add an additional paragraph (C) covering Gulf War veterans to 5 U.S.C. 2108(1) (on who is eligible for preference). But, significantly, the law made no other changes to existing law. In particular, it did not change paragraph (4) of section 2108 (the Dual Compensation Act of 1973), which severely restricts preference entitlement for retired officers at the rank of Major and above. When the Dual Compensation Act was under consideration, there was extensive debate in Congress as to who should be entitled to preference. Congress basically compromised by giving preference in appointment to most retired military members (except for "high-ranking officers" who were not considered to need it), but severely limiting preference in RIF for all retired military because they had already served one career and should not have preference in the event of layoffs.
+So, "otherwise eligible" means that the individual must be eligible under existing law.
+
+**Which provision of the new law contains the 24 month service requirement for regular military service members on active duty as opposed to reservists who are called or ordered to active duty?**
+
+The 24 month service requirement provision is found in Section 5303A of title 38, United States Code which defines the minimum active-duty service requirement for those who initially enter active duty after September 7, 1980.
+
+**Can an applicant claim preference based on Gulf War service after January 2, 1992?**
+
+The law specifies that only those on active duty during the period beginning August 2, 1990, and ending January 2, 1992, are eligible for preference. Applicants who served on active duty exclusively after these dates would have to be in receipt of a campaign badge or expeditionary medal.
+
+**Are there any plans to extend Veterans' preference to any other groups of individuals who served on active duty during times of conflict that may not have served in specific theaters of operation?**
+
+We are not aware of any plans to extend Veterans' preference to any other group of individuals.
+
+**An applicant is claiming preference based on service in Bosnia, but he/she has no DD Form 214 to support his claim. Can we give him/her preference?**
+
+A service member whose record appears to show service qualifying for Veterans' preference (for example, there is an indication that the person served in Bosnia in 1996), may be accorded 5 points tentative preference on that basis alone. However, before the person can be appointed, he or she must submit proof of entitlement to preference. That proof may be an amended DD Form 214 showing the award of the Armed Forces Expeditionary Medal (AFEM) for Bosnia in the case of service members who served there and were released prior to enactment of the recent Veterans' preference amendments, or it may be other official documentation showing award of the Armed Forces Expeditionary Medal.
+
+**How are we to know that a Reservist was, in fact, a) called to active duty, and b) served the full period for which called? Don't some Reservists just receive a letter telling them they are being placed on active duty?**
+
+A Reservist will always have orders placing him (or her) on active duty -- (it is the only way the Reservist can be paid). While the individual may also have a letter saying that he or she is being called up, there will always be orders backing this up. Similarly, when the Reservist is released from active duty, he or she will always have separation or demobilization orders.
+
+**Several employees have come to the agency personnel office claiming they should have preference under the new law, but they have no proof of service during the specified period. We are getting ready to issue Reduction In Force (RIF) notices. Should we take the employees' word for it or wait until they have proof?**
+
+The employees cannot be given Veterans' preference without required documentation. The agency should work with the employee and the appropriate military service record organizations to obtain this documentation as soon as possible to avoid having to "rerun" the Reduction In Force at the last minute.
+
+**If our agency has "frozen" personnel actions and issued Reduction In Force notices but the Reduction In Force effective date has not yet arrived, how can we account for any changes in Veterans' preference status?**
+
+Regardless of where you are in the process of carrying out the Reduction In Force, you must correct the Veterans' preference of employees who will now be eligible as a result of the statute. Veterans' preference cannot be "frozen" like qualifications or performance appraisals--it must be corrected right up until the day of the Reduction In Force. If a change in preference results in a different outcome for one or more employees, amended Reduction In Force notices must be issued. If such a change results in a worse offer, the affected employee must be given a full 60/120 day notice period required by regulation. This may require the agency to use a temporary exception to keep one or more employees on the rolls past the Reduction In Force effective date in order to meet this obligation.
+
+**Our agency already completed a Reduction In Force effective November 28, 1997. There is at least one separated employee who would now have Veterans' preference and would not have been separated if we had known about the change in statute. What do we do now?**
+
+If an agency finds that an eligible employee reached for Reduction In Force separation or downgrading effective on or after November 18, 1997, was not provided retention preference consistent with P.L. 105-85, The Office of Personnel Management recommends that the agency take appropriate corrective action.
+An employee not provided appropriate retention preference may appeal the Reduction In Force action to the Merit Systems Protection Board (MSPB). MSPB normally requires the appeal to be filed within 30 days of the Reduction In Force effective date, but Merit Systems Protection Board may, at its option, accept later appeals filed within 30 days of the employee becoming aware of the change.
+If an employee was separated or downgraded by Reduction In Force, the agency should determine whether or not the employee would have been affected differently based on the change in Veterans' preference. If the employee would still be separated or downgraded, the agency should correct the employee's notice. If the employee was separated, the agency should also correct the Reemployment Priority List (RPL) registration (if any) to accurately reflect their Veterans' preference.
+If the corrective action results in a surplus of employees in one or more competitive levels, the agency may have to run a new Reduction In Force. However, the agency cannot retroactively adjust the results of the prior Reduction In Force.
+
+**What if an employee would have been registered as a I-A on the agency's Reemployment Priority List due to the new law, but has been listed as a I-B? What is the agency's obligation to make up for any lost consideration as a result?**
+
+The employee's registration status on the Reemployment Priority List should be corrected immediately so that the employee will be considered as a I-A for the remainder of their time on the Reemployment Priority List. If the agency finds that a lower standing person was selected over the employee, the agency must notify the employee of the selection and their right to appeal to Merit Systems Protection Board. If the employee files a Reemployment Priority List appeal, Merit Systems Protection Board may order a retroactive remedy which could include extending the employee's time period for consideration under the Reemployment Priority List.
+
+## Questions and Answers (VEOA)
+
+**Do the amendments made by Pub. L. 106-117 mean that agencies may no longer use authority code YKB/SchB 213.3202(n) to appoint eligible veterans under the Veterans Employment Opportunities Act of 1998 (VEOA)?**
+
+As of the date of enactment of the new amendments (November 30, 1999), agencies should not make any new appointments under the Schedule B authority. However, we are allowing a 1-month grace period to cover any appointments under the Schedule B authority that may already have been in progress.
+
+**If VEOA-eligible veterans should no longer be appointed under the above Schedule B authority, how are they appointed?**
+
+The law provides that preference eligibles or eligible veterans who compete under agency Merit Promotion procedures open to candidates outside the agency ("agency" in this context means the parent agency such as Treasury, not IRS), and who are selected from among the best qualified, shall receive a career or career conditional appointment, as appropriate. Agencies should use the authority ZBA-Pub.L. 106-117, Sec 511 for these appointments.
+
+**What happens to veterans who were appointed under Schedule B?**
+
+Agencies should first determine whether their Schedule B appointees actually competed under Merit Promotion procedures or were selected noncompetitively as a separate source of eligibles.
+Those veterans who competed under agency Merit Promotion procedures are to be converted to career conditional (or career) retroactive to the date of their original appointments. These individuals will have been serving probation as of the original date of their appointments and this must be made clear to the employees.
+Those veterans who did not compete under an agency Merit Promotion announcement and were given a Schedule B appointment noncompetitively, remain under Schedule B until such time as they can be appointed based on competition ? either under Merit Promotion procedures open to candidates outside the agency or through an open competitive announcement. Because an employee may remain under the Schedule B authority until such time as he or she is selected competitively, we are leaving the authority in place indefinitely; he or she may not be required to compete for a career conditional position.
+
+**Did the new amendments change the eligibility criteria for appointment under the VEOA?**
+
+Yes. Prior to these amendments, a veteran had to be either a preference eligible or have at least 3 years of continuous active duty military service in order to qualify for appointment under the VEOA. The new amendments provide that OPM is authorized to regulate the circumstances under which individuals who were released from active duty "shortly before completing 3 years of active duty" may be appointed. In our interim regulations implementing this provision, we are proposing to use the term "substantially completed an initial 3-year term." Agencies will then decide, in individual cases, whether a candidate has met this standard. In general, most individuals completing an initial 3-year military tour are typically released a few days early. These individuals, if otherwise qualified, should be considered eligible.
+
+**Does Veterans' preference apply to appointments under the VEOA?**
+
+No. Veterans preference does not apply to merit promotion actions.
+
+**Are eligible veterans permitted to apply for vacancies that are open to CTAP candidates only?**
+
+No. Since CTAP is limited to internal agency candidates, VEOA eligibles may not apply.
+
+**Are eligible veterans permitted to apply for vacancies that are open to ICTAP candidates only?**
+
+Yes. Since ICTAP is open to candidates outside the agency, the law requires that VEOA eligibles be allowed to apply.
+
+**Do VEOA appointees serve a probationary period?**
+
+Yes. Since they are appointed in the competitive service, they are subject to a probationary period. Please note, however, that for those employees converted from the Schedule B authority, prior service counts towards completion of probation provided it is in the same agency, same line of work, and without a break in service. Where applicable, agencies must inform individuals that their original appointment under the VEOA authority marked the beginning of a probationary period.
+
+**Can VEOA candidates be considered for temporary and term positions?**
+
+No. Because VEOA mandates that eligible veterans be given career or career conditional appointments, temporary or term appointments cannot be offered.
+
+**Can a current career/career conditional employee who lacks time-in-grade apply as a VEOA candidate under an agency merit promotion announcement?**
+
+No. Such an employee remains subject to time-in-grade restrictions. The VEOA is not a noncompetitive-entry authority like the VRA where an employee could be given a new appointment at a higher grade.
+
+**Can a current career/career conditional employee who meets time-in-grade and eligibility requirements apply as a VEOA candidate under an agency merit promotion announcement and, if selected, be given a new career/career conditional appointment using the VEOA appointing authority?**
+
+Yes. Currently, a career/career conditional employee who meets time-in-grade and eligibility requirements would be able to apply directly to a merit promotion announcement without the need to use the VEOA authority. However, under the plain language of the VEOA, the law would allow current career/career conditional Federal employees who are preference eligibles or veterans meeting the eligibility criteria of the vacancy announcement to apply to those positions advertised under an agency's merit promotion procedures when seeking candidates from outside its own workforce. The term preference eligibles is defined in title 5, United States Code section 2108.
+
+**Can a current career/career conditional employee who meets time-in-grade and eligibility requirements apply as a VEOA candidate under an agency merit promotion announcement when he or she is outside the stated area of consideration?**
+
+Yes. A career/career conditional employee who meets time-in-grade and eligibility requirements would be able to apply using VEOA to a merit promotion announcement when outside the stated area of
+consideration.
+
+**Can a preference eligible or eligible veteran who is outside the agency merit promotion announcement's area of consideration apply as a VEOA candidate?**
+
+Yes. A preference eligible or eligible veteran would be able to apply using VEOA to a merit promotion announcement even though he or she is outside the vacancy announcement's area of consideration.
+
+**We understand that VEOA eligibles are expected to compete with agency merit promotion eligibles under the agency's merit promotion plan. But, is the agency expected to create a different crediting plan for considering VEOA candidates?**
+
+No. VEOA candidates are considered along with agency candidates, and under the same crediting plan.
+
+**To be eligible for an appointment under the VEOA authority, a veteran must be "separated" from the service. Does this mean that he or she cannot apply and be considered until actually separated?**
+
+No. Whether or not to consider someone who is still in the military is entirely at the discretion of the employing agency. By law, a person on military duty cannot be appointed to a civilian position (unless on terminal leave), but he or she can certainly be considered should the agency wish to do so. The determining factor, here, should be whether the person will be available when the agency needs to have the job filled.

--- a/faqs_content.txt
+++ b/faqs_content.txt
@@ -1,0 +1,198 @@
+Questions and Answers about Gulf War Preference
+* Public Law 105-85 of November 18, 1997, contains a provision (section 1102 of Title XI)
+which accords Veterans' preference to anyone who served on active duty, anywhere in
+the world, for any length of time between August 2, 1990, and January 2, 1992, provided
+the person is "otherwise eligible." What does "otherwise eligible" mean, here?
+It means the person must have been separated from the service under honorable conditions and have
+served continuously for a minimum of 24 months or the full period for which called or ordered to
+active duty. For example, someone who enlisted in the Army and was serving on active duty when the
+Gulf War broke out on Aug 2, 1990, would have to complete a minimum of 24 months service to be
+eligible for preference. On the other hand a Reservist who was called to active duty for a month and
+spent all his time at the Pentagon before being released would also be eligible. What the law did was to
+add an additional paragraph (C) covering Gulf War veterans to 5 U.S.C. 2108(1) (on who is eligible for
+preference). But, significantly, the law made no other changes to existing law. In particular, it did not
+change paragraph (4) of section 2108 (the Dual Compensation Act of 1973), which severely restricts
+preference entitlement for retired officers at the rank of Major and above. When the Dual
+Compensation Act was under consideration, there was extensive debate in Congress as to who should
+be entitled to preference. Congress basically compromised by giving preference in appointment to
+most retired military members (except for "high-ranking officers" who were not considered to need it),
+but severely limiting preference in RIF for all retired military because they had already served one
+career and should not have preference in the event of layoffs.
+So, "otherwise eligible" means that the individual must be eligible under existing law.
+* Which provision of the new law contains the 24 month service requirement for regular
+military service members on active duty as opposed to reservists who are called or
+ordered to active duty?
+The 24 month service requirement provision is found in Section 5303A of title 38, United States Code
+which defines the minimum active-duty service requirement for those who initially enter active duty
+after September 7, 1980.
+* Can an applicant claim preference based on Gulf War service after January 2, 1992?
+The law specifies that only those on active duty during the period beginning August 2, 1990, and
+ending January 2, 1992, are eligible for preference. Applicants who served on active duty exclusively
+after these dates would have to be in receipt of a campaign badge or expeditionary medal.
+* Are there any plans to extend Veterans' preference to any other groups of individuals
+who served on active duty during times of conflict that may not have served in specific
+theaters of operation?
+We are not aware of any plans to extend Veterans' preference to any other group of individuals.
+* An applicant is claiming preference based on service in Bosnia, but he/she has no DD
+Form 214 to support his claim. Can we give him/her preference?
+A service member whose record appears to show service qualifying for Veterans' preference (for
+example, there is an indication that the person served in Bosnia in 1996), may be accorded 5 points
+tentative preference on that basis alone. However, before the person can be appointed, he or she must
+submit proof of entitlement to preference. That proof may be an amended DD Form 214 showing the
+award of the Armed Forces Expeditionary Medal (AFEM) for Bosnia in the case of service members
+who served there and were released prior to enactment of the recent Veterans' preference
+amendments, or it may be other official documentation showing award of the Armed Forces
+Expeditionary Medal.
+* How are we to know that a Reservist was, in fact, a) called to active duty, and b) served
+the full period for which called? Don't some Reservists just receive a letter telling them
+they are being placed on active duty?
+A Reservist will always have orders placing him (or her) on active duty -- (it is the only way the
+Reservist can be paid). While the individual may also have a letter saying that he or she is being called
+up, there will always be orders backing this up. Similarly, when the Reservist is released from active
+duty, he or she will always have separation or demobilization orders.
+* Several employees have come to the agency personnel office claiming they should have
+preference under the new law, but they have no proof of service during the specified
+period. We are getting ready to issue Reduction In Force (RIF) notices. Should we take
+the employees' word for it or wait until they have proof?
+The employees cannot be given Veterans' preference without required documentation. The agency
+should work with the employee and the appropriate military service record organizations to obtain this
+documentation as soon as possible to avoid having to "rerun" the Reduction In Force at the last
+minute.
+* If our agency has "frozen" personnel actions and issued Reduction In Force notices but
+the Reduction In Force effective date has not yet arrived, how can we account for any
+changes in Veterans' preference status?
+Regardless of where you are in the process of carrying out the Reduction In Force, you must correct
+the Veterans' preference of employees who will now be eligible as a result of the statute. Veterans'
+preference cannot be "frozen" like qualifications or performance appraisals--it must be corrected right
+up until the day of the Reduction In Force. If a change in preference results in a different outcome for
+one or more employees, amended Reduction In Force notices must be issued. If such a change results
+in a worse offer, the affected employee must be given a full 60/120 day notice period required by
+regulation. This may require the agency to use a temporary exception to keep one or more employees
+on the rolls past the Reduction In Force effective date in order to meet this obligation.
+* Our agency already completed a Reduction In Force effective November 28, 1997. There
+is at least one separated employee who would now have Veterans' preference and would
+not have been separated if we had known about the change in statute. What do we do
+now?
+If an agency finds that an eligible employee reached for Reduction In Force separation or downgrading
+effective on or after November 18, 1997, was not provided retention preference consistent with P.L.
+105-85, The Office of Personnel Management recommends that the agency take appropriate corrective
+action.
+An employee not provided appropriate retention preference may appeal the Reduction In Force action
+to the Merit Systems Protection Board (MSPB). MSPB normally requires the appeal to be filed within
+30 days of the Reduction In Force effective date, but Merit Systems Protection Board may, at its
+option, accept later appeals filed within 30 days of the employee becoming aware of the change.
+If an employee was separated or downgraded by Reduction In Force, the agency should determine
+whether or not the employee would have been affected differently based on the change in Veterans'
+preference. If the employee would still be separated or downgraded, the agency should correct the
+employee's notice. If the employee was separated, the agency should also correct the Reemployment
+Priority List (RPL) registration (if any) to accurately reflect their Veterans' preference.
+If the corrective action results in a surplus of employees in one or more competitive levels, the agency
+may have to run a new Reduction In Force. However, the agency cannot retroactively adjust the results
+of the prior Reduction In Force.
+* What if an employee would have been registered as a I-A on the agency's Reemployment
+Priority List due to the new law, but has been listed as a I-B? What is the agency's
+obligation to make up for any lost consideration as a result?
+The employee's registration status on the Reemployment Priority List should be corrected immediately
+so that the employee will be considered as a I-A for the remainder of their time on the Reemployment
+Priority List. If the agency finds that a lower standing person was selected over the employee, the
+agency must notify the employee of the selection and their right to appeal to Merit Systems Protection
+Board. If the employee files a Reemployment Priority List appeal, Merit Systems Protection Board may
+order a retroactive remedy which could include extending the employee's time period for
+consideration under the Reemployment Priority List.
+
+Questions and Answers (VEOA)
+* Do the amendments made by Pub. L. 106-117 mean that agencies may no longer use
+authority code YKB/SchB 213.3202(n) to appoint eligible veterans under the Veterans
+Employment Opportunities Act of 1998 (VEOA)?
+As of the date of enactment of the new amendments (November 30, 1999), agencies should not make
+any new appointments under the Schedule B authority. However, we are allowing a 1-month grace
+period to cover any appointments under the Schedule B authority that may already have been in
+progress.
+* If VEOA-eligible veterans should no longer be appointed under the above Schedule B
+authority, how are they appointed?
+The law provides that preference eligibles or eligible veterans who compete under agency Merit
+Promotion procedures open to candidates outside the agency ("agency" in this context means the
+parent agency such as Treasury, not IRS), and who are selected from among the best qualified, shall
+receive a career or career conditional appointment, as appropriate. Agencies should use the authority
+ZBA-Pub.L. 106-117, Sec 511 for these appointments.
+* What happens to veterans who were appointed under Schedule B?
+Agencies should first determine whether their Schedule B appointees actually competed under Merit
+Promotion procedures or were selected noncompetitively as a separate source of eligibles.
+Those veterans who competed under agency Merit Promotion procedures are to be converted to career
+conditional (or career) retroactive to the date of their original appointments. These individuals will
+have been serving probation as of the original date of their appointments and this must be made clear
+to the employees.
+Those veterans who did not compete under an agency Merit Promotion announcement and were given
+a Schedule B appointment noncompetitively, remain under Schedule B until such time as they can be
+appointed based on competition ? either under Merit Promotion procedures open to candidates
+outside the agency or through an open competitive announcement. Because an employee may remain
+under the Schedule B authority until such time as he or she is selected competitively, we are leaving
+the authority in place indefinitely; he or she may not be required to compete for a career conditional position.
+* Did the new amendments change the eligibility criteria for appointment under the
+VEOA?
+Yes. Prior to these amendments, a veteran had to be either a preference eligible or have at least 3 years
+of continuous active duty military service in order to qualify for appointment under the VEOA. The
+new amendments provide that OPM is authorized to regulate the circumstances under which
+individuals who were released from active duty "shortly before completing 3 years of active duty" may
+be appointed. In our interim regulations implementing this provision, we are proposing to use the
+term "substantially completed an initial 3-year term." Agencies will then decide, in individual cases,
+whether a candidate has met this standard. In general, most individuals completing an initial 3-year
+military tour are typically released a few days early. These individuals, if otherwise qualified, should be
+considered eligible.
+* Does Veterans' preference apply to appointments under the VEOA?
+No. Veterans preference does not apply to merit promotion actions.
+* Are eligible veterans permitted to apply for vacancies that are open to CTAP candidates
+only?
+No. Since CTAP is limited to internal agency candidates, VEOA eligibles may not apply.
+* Are eligible veterans permitted to apply for vacancies that are open to ICTAP candidates
+only?
+Yes. Since ICTAP is open to candidates outside the agency, the law requires that VEOA eligibles be
+allowed to apply.
+* Do VEOA appointees serve a probationary period?
+Yes. Since they are appointed in the competitive service, they are subject to a probationary period.
+Please note, however, that for those employees converted from the Schedule B authority, prior service
+counts towards completion of probation provided it is in the same agency, same line of work, and
+without a break in service. Where applicable, agencies must inform individuals that their original
+appointment under the VEOA authority marked the beginning of a probationary period.
+* Can VEOA candidates be considered for temporary and term positions?
+No. Because VEOA mandates that eligible veterans be given career or career conditional
+appointments, temporary or term appointments cannot be offered.
+* Can a current career/career conditional employee who lacks time-in-grade apply as a
+VEOA candidate under an agency merit promotion announcement?
+No. Such an employee remains subject to time-in-grade restrictions. The VEOA is not a
+noncompetitive-entry authority like the VRA where an employee could be given a new appointment at
+a higher grade.
+* Can a current career/career conditional employee who meets time-in-grade and
+eligibility requirements apply as a VEOA candidate under an agency merit promotion
+announcement and, if selected, be given a new career/career conditional appointment
+using the VEOA appointing authority?
+Yes. Currently, a career/career conditional employee who meets time-in-grade and eligibility
+requirements would be able to apply directly to a merit promotion announcement without the need to
+use the VEOA authority. However, under the plain language of the VEOA, the law would allow current
+career/career conditional Federal employees who are preference eligibles or veterans meeting the
+eligibility criteria of the vacancy announcement to apply to those positions advertised under an
+agency's merit promotion procedures when seeking candidates from outside its own workforce. The
+term preference eligibles is defined in title 5, United States Code section 2108.
+* Can a current career/career conditional employee who meets time-in-grade and
+eligibility requirements apply as a VEOA candidate under an agency merit promotion
+announcement when he or she is outside the stated area of consideration?
+Yes. A career/career conditional employee who meets time-in-grade and eligibility requirements
+would be able to apply using VEOA to a merit promotion announcement when outside the stated area
+of consideration.
+* Can a preference eligible or eligible veteran who is outside the agency merit promotion
+announcement's area of consideration apply as a VEOA candidate?
+Yes. A preference eligible or eligible veteran would be able to apply using VEOA to a merit promotion
+announcement even though he or she is outside the vacancy announcement's area of consideration.
+* We understand that VEOA eligibles are expected to compete with agency merit
+promotion eligibles under the agency's merit promotion plan. But, is the agency
+expected to create a different crediting plan for considering VEOA candidates?
+No. VEOA candidates are considered along with agency candidates, and under the same crediting
+plan.
+* To be eligible for an appointment under the VEOA authority, a veteran must be
+"separated" from the service. Does this mean that he or she cannot apply and be
+considered until actually separated?
+No. Whether or not to consider someone who is still in the military is entirely at the discretion of the
+employing agency. By law, a person on military duty cannot be appointed to a civilian position (unless
+on terminal leave), but he or she can certainly be considered should the agency wish to do so. The
+determining factor, here, should be whether the person will be available when the agency needs to
+have the job filled.

--- a/preference-types.md
+++ b/preference-types.md
@@ -4,39 +4,25 @@ title: Preference Types
 permalink: /preference-types/
 ---
 
-To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces
-under honorable conditions (i.e., with an honorable or general discharge). As defined in 5 U.S.C. 2101(2),
-"Armed Forces" means the Army, Navy, Air Force, Marine Corps and Coast Guard. The veteran must also be
-eligible under one of the preference categories below (also shown on the Standard Form (SF) 50,
-Notification of Personnel Action).
+## Types of Preference
 
-Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in
-appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing
-military retired pay until age 60.)
+To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions (i.e., with an honorable or general discharge). As defined in 5 U.S.C. 2101(2), "Armed Forces" means the Army, Navy, Air Force, Marine Corps and Coast Guard. The veteran must also be eligible under one of the preference categories below (also shown on the Standard Form (SF) 50, Notification of Personnel Action).
 
-For non-disabled users, active duty for training by National Guard or Reserve soldiers does not qualify as
-"active duty" for preference.
+Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)
 
-For disabled veterans, active duty includes training service in the Reserves or National Guard, per the Merit
-Systems Protection Board decision in Hesse v. Department of the Army, 104 M.S.P.R.647(2007).
+For non-disabled users, active duty for training by National Guard or Reserve soldiers does not qualify as "active duty" for preference.
 
-For purposes of this chapter and 5 U.S.C. 2108, "war" means only those armed conflicts declared by
-Congress as war and includes World War II, which covers the period from December 7, 1941, to April 28,
-1952.
+For disabled veterans, active duty includes training service in the Reserves or National Guard, per the Merit Systems Protection Board decision in Hesse v. Department of the Army, 104 M.S.P.R.647(2007).
 
-When applying for Federal jobs, eligible veterans should claim preference on their application or resume.
-Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point
-Veteran Preference, and submit the requested documentation.
+For purposes of this chapter and 5 U.S.C. 2108, "war" means only those armed conflicts declared by Congress as war and includes World War II, which covers the period from December 7, 1941, to April 28, 1952.
 
-The following preference categories and points are based on 5 U.S.C. 2108 and 3309 as modified by a length
-of service requirement in 38 U.S.C. 5303A(d).
+When applying for Federal jobs, eligible veterans should claim preference on their application or resume. Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation.
+
+The following preference categories and points are based on 5 U.S.C. 2108 and 3309 as modified by a length of service requirement in 38 U.S.C. 5303A(d).
 
 ## 0-point Preference (SSP)
-On August 29, 2008, the Hubbard Act was enacted as Public Law 110-317. The Hubbard Act amended the
-eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3).
-Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or
-discharged from a period of active duty from the armed forces, after August 29, 2008, by reason of a “sole
-survivorship discharge.”
+
+On August 29, 2008, the Hubbard Act was enacted as Public Law 110-317. The Hubbard Act amended the eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3). Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or discharged from a period of active duty from the armed forces, after August 29, 2008, by reason of a “sole survivorship discharge.”
 
 Under the sole survivorship preference, the individual:
 * does not receive veterans’ preference points as other preference eligibles do when the “rule of 3” is applied;
@@ -44,286 +30,156 @@ Under the sole survivorship preference, the individual:
 * is entitled to receive the same pass over rights as other preference eligibles; and
 * is entitled to credit experience in the armed forces to meet the qualification requirements for Federal jobs.
 
-No points are added to the passing score or rating of a veteran who is the only surviving child in a family in
-which the father or mother or one or more siblings:
+No points are added to the passing score or rating of a veteran who is the only surviving child in a family in which the father or mother or one or more siblings:
 * served in the armed forces, and
-* was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status,
-or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed
-gainfully because of the disability or hospitalization), where
-* the death, status, or disability did not result from the intentional misconduct or willful neglect of the
-parent or sibling and was not incurred during a period of unauthorized absence.
+* was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status, or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed gainfully because of the disability or hospitalization), where
+* the death, status, or disability did not result from the intentional misconduct or willful neglect of the parent or sibling and was not incurred during a period of unauthorized absence.
 
 ## 5-Point Preference (TP)
+
 Five points are added to the passing examination score or rating of a veteran who served:
 * During a war; or
 * During the period April 28, 1952 through July 1, 1955; or
-* For more than 180 consecutive days, other than for training, any part of which occurred after January
-31, 1955, and before October 15, 1976; or
+* For more than 180 consecutive days, other than for training, any part of which occurred after January 31, 1955, and before October 15, 1976; or
 * During the Gulf War from August 2, 1990, through January 2, 1992; or
-* For more than 180 consecutive days, other than for training, any part of which occurred during the
-period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi
-Freedom; or
-* In a campaign or expedition for which a campaign medal has been authorized. Any Armed Forces
-Expeditionary medal or campaign badge, including El Salvador, Lebanon, Grenada, Panama,
-Southwest Asia, Somalia, and Haiti, qualifies for preference.
+* For more than 180 consecutive days, other than for training, any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi Freedom; or
+* In a campaign or expedition for which a campaign medal has been authorized. Any Armed Forces Expeditionary medal or campaign badge, including El Salvador, Lebanon, Grenada, Panama, Southwest Asia, Somalia, and Haiti, qualifies for preference.
 
-A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began
-active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active
-duty) must have served continuously for 24 months or the full period called or ordered to active duty. The
-24-month service requirement does not apply to 10-point preference eligibles separated for disability
-incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10
-U.S.C. 1171 or 1173.
+A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active duty) must have served continuously for 24 months or the full period called or ordered to active duty. The 24-month service requirement does not apply to 10-point preference eligibles separated for disability incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10 U.S.C. 1171 or 1173.
 
-### A word about Gulf War Preference
-The Defense Authorization Act of Fiscal Year 1998 (Public Law 105-85) of November 18, 1997, contains a
-provision (section 1102 of Title XI) which accords Veterans' preference to everyone who served on active
-duty during the period beginning August 2, 1990, and ending January 2, 1992, provided, of course, the
-veteran is otherwise eligible.
-This means that anyone who served on active duty during the Gulf War, regardless of where or for how long,
-is entitled to preference if otherwise eligible (i.e., have been separated under honorable conditions and
-served continuously for a minimum of 24 months or the full period for which called or ordered to active
-duty). This applies not only to candidates seeking employment, but to Federal employees who may be
-affected by reduction in force, as well.
+## A word about Gulf War Preference
 
-**Questions and Answers about Gulf War Preference**
-* Public Law 105-85 of November 18, 1997, contains a provision (section 1102 of Title XI)
-which accords Veterans' preference to anyone who served on active duty, anywhere in
-the world, for any length of time between August 2, 1990, and January 2, 1992, provided
-the person is "otherwise eligible." What does "otherwise eligible" mean, here?
-It means the person must have been separated from the service under honorable conditions and have
-served continuously for a minimum of 24 months or the full period for which called or ordered to
-active duty. For example, someone who enlisted in the Army and was serving on active duty when the
-Gulf War broke out on Aug 2, 1990, would have to complete a minimum of 24 months service to be
-eligible for preference. On the other hand a Reservist who was called to active duty for a month and
-spent all his time at the Pentagon before being released would also be eligible. What the law did was to
-add an additional paragraph (C) covering Gulf War veterans to 5 U.S.C. 2108(1) (on who is eligible for
-preference). But, significantly, the law made no other changes to existing law. In particular, it did not
-change paragraph (4) of section 2108 (the Dual Compensation Act of 1973), which severely restricts
-preference entitlement for retired officers at the rank of Major and above. When the Dual
-Compensation Act was under consideration, there was extensive debate in Congress as to who should
-be entitled to preference. Congress basically compromised by giving preference in appointment to
-most retired military members (except for "high-ranking officers" who were not considered to need it),
-but severely limiting preference in RIF for all retired military because they had already served one
-career and should not have preference in the event of layoffs.
+The Defense Authorization Act of Fiscal Year 1998 (Public Law 105-85) of November 18, 1997, contains a provision (section 1102 of Title XI) which accords Veterans' preference to everyone who served on active duty during the period beginning August 2, 1990, and ending January 2, 1992, provided, of course, the veteran is otherwise eligible.
+
+This means that anyone who served on active duty during the Gulf War, regardless of where or for how long, is entitled to preference if otherwise eligible (i.e., have been separated under honorable conditions and served continuously for a minimum of 24 months or the full period for which called or ordered to active duty). This applies not only to candidates seeking employment, but to Federal employees who may be affected by reduction in force, as well.
+
+### Questions and Answers about Gulf War Preference
+
+**Public Law 105-85 of November 18, 1997, contains a provision (section 1102 of Title XI) which accords Veterans' preference to anyone who served on active duty, anywhere in the world, for any length of time between August 2, 1990, and January 2, 1992, provided the person is "otherwise eligible." What does "otherwise eligible" mean, here?**
+
+It means the person must have been separated from the service under honorable conditions and have served continuously for a minimum of 24 months or the full period for which called or ordered to active duty. For example, someone who enlisted in the Army and was serving on active duty when the Gulf War broke out on Aug 2, 1990, would have to complete a minimum of 24 months service to be eligible for preference. On the other hand a Reservist who was called to active duty for a month and spent all his time at the Pentagon before being released would also be eligible. What the law did was to add an additional paragraph (C) covering Gulf War veterans to 5 U.S.C. 2108(1) (on who is eligible for preference). But, significantly, the law made no other changes to existing law. In particular, it did not change paragraph (4) of section 2108 (the Dual Compensation Act of 1973), which severely restricts preference entitlement for retired officers at the rank of Major and above. When the Dual Compensation Act was under consideration, there was extensive debate in Congress as to who should be entitled to preference. Congress basically compromised by giving preference in appointment to most retired military members (except for "high-ranking officers" who were not considered to need it), but severely limiting preference in RIF for all retired military because they had already served one career and should not have preference in the event of layoffs.
 So, "otherwise eligible" means that the individual must be eligible under existing law.
-* Which provision of the new law contains the 24 month service requirement for regular
-military service members on active duty as opposed to reservists who are called or
-ordered to active duty?
-The 24 month service requirement provision is found in Section 5303A of title 38, United States Code
-which defines the minimum active-duty service requirement for those who initially enter active duty
-after September 7, 1980.
-* Can an applicant claim preference based on Gulf War service after January 2, 1992?
-The law specifies that only those on active duty during the period beginning August 2, 1990, and
-ending January 2, 1992, are eligible for preference. Applicants who served on active duty exclusively
-after these dates would have to be in receipt of a campaign badge or expeditionary medal.
-* Are there any plans to extend Veterans' preference to any other groups of individuals
-who served on active duty during times of conflict that may not have served in specific
-theaters of operation?
+
+**Which provision of the new law contains the 24 month service requirement for regular military service members on active duty as opposed to reservists who are called or ordered to active duty?**
+
+The 24 month service requirement provision is found in Section 5303A of title 38, United States Code which defines the minimum active-duty service requirement for those who initially enter active duty after September 7, 1980.
+
+**Can an applicant claim preference based on Gulf War service after January 2, 1992?**
+
+The law specifies that only those on active duty during the period beginning August 2, 1990, and ending January 2, 1992, are eligible for preference. Applicants who served on active duty exclusively after these dates would have to be in receipt of a campaign badge or expeditionary medal.
+
+**Are there any plans to extend Veterans' preference to any other groups of individuals who served on active duty during times of conflict that may not have served in specific theaters of operation?**
+
 We are not aware of any plans to extend Veterans' preference to any other group of individuals.
-* An applicant is claiming preference based on service in Bosnia, but he/she has no DD
-Form 214 to support his claim. Can we give him/her preference?
-A service member whose record appears to show service qualifying for Veterans' preference (for
-example, there is an indication that the person served in Bosnia in 1996), may be accorded 5 points
-tentative preference on that basis alone. However, before the person can be appointed, he or she must
-submit proof of entitlement to preference. That proof may be an amended DD Form 214 showing the
-award of the Armed Forces Expeditionary Medal (AFEM) for Bosnia in the case of service members
-who served there and were released prior to enactment of the recent Veterans' preference
-amendments, or it may be other official documentation showing award of the Armed Forces
-Expeditionary Medal.
-* How are we to know that a Reservist was, in fact, a) called to active duty, and b) served
-the full period for which called? Don't some Reservists just receive a letter telling them
-they are being placed on active duty?
-A Reservist will always have orders placing him (or her) on active duty -- (it is the only way the
-Reservist can be paid). While the individual may also have a letter saying that he or she is being called
-up, there will always be orders backing this up. Similarly, when the Reservist is released from active
-duty, he or she will always have separation or demobilization orders.
-* Several employees have come to the agency personnel office claiming they should have
-preference under the new law, but they have no proof of service during the specified
-period. We are getting ready to issue Reduction In Force (RIF) notices. Should we take
-the employees' word for it or wait until they have proof?
-The employees cannot be given Veterans' preference without required documentation. The agency
-should work with the employee and the appropriate military service record organizations to obtain this
-documentation as soon as possible to avoid having to "rerun" the Reduction In Force at the last
-minute.
-* If our agency has "frozen" personnel actions and issued Reduction In Force notices but
-the Reduction In Force effective date has not yet arrived, how can we account for any
-changes in Veterans' preference status?
-Regardless of where you are in the process of carrying out the Reduction In Force, you must correct
-the Veterans' preference of employees who will now be eligible as a result of the statute. Veterans'
-preference cannot be "frozen" like qualifications or performance appraisals--it must be corrected right
-up until the day of the Reduction In Force. If a change in preference results in a different outcome for
-one or more employees, amended Reduction In Force notices must be issued. If such a change results
-in a worse offer, the affected employee must be given a full 60/120 day notice period required by
-regulation. This may require the agency to use a temporary exception to keep one or more employees
-on the rolls past the Reduction In Force effective date in order to meet this obligation.
-* Our agency already completed a Reduction In Force effective November 28, 1997. There
-is at least one separated employee who would now have Veterans' preference and would
-not have been separated if we had known about the change in statute. What do we do
-now?
-If an agency finds that an eligible employee reached for Reduction In Force separation or downgrading
-effective on or after November 18, 1997, was not provided retention preference consistent with P.L.
-105-85, The Office of Personnel Management recommends that the agency take appropriate corrective
-action.
-An employee not provided appropriate retention preference may appeal the Reduction In Force action
-to the Merit Systems Protection Board (MSPB). MSPB normally requires the appeal to be filed within
-30 days of the Reduction In Force effective date, but Merit Systems Protection Board may, at its
-option, accept later appeals filed within 30 days of the employee becoming aware of the change.
-If an employee was separated or downgraded by Reduction In Force, the agency should determine
-whether or not the employee would have been affected differently based on the change in Veterans'
-preference. If the employee would still be separated or downgraded, the agency should correct the
-employee's notice. If the employee was separated, the agency should also correct the Reemployment
-Priority List (RPL) registration (if any) to accurately reflect their Veterans' preference.
-If the corrective action results in a surplus of employees in one or more competitive levels, the agency
-may have to run a new Reduction In Force. However, the agency cannot retroactively adjust the results
-of the prior Reduction In Force.
-* What if an employee would have been registered as a I-A on the agency's Reemployment
-Priority List due to the new law, but has been listed as a I-B? What is the agency's
-obligation to make up for any lost consideration as a result?
-The employee's registration status on the Reemployment Priority List should be corrected immediately
-so that the employee will be considered as a I-A for the remainder of their time on the Reemployment
-Priority List. If the agency finds that a lower standing person was selected over the employee, the
-agency must notify the employee of the selection and their right to appeal to Merit Systems Protection
-Board. If the employee files a Reemployment Priority List appeal, Merit Systems Protection Board may
-order a retroactive remedy which could include extending the employee's time period for
-consideration under the Reemployment Priority List.
+
+**An applicant is claiming preference based on service in Bosnia, but he/she has no DD Form 214 to support his claim. Can we give him/her preference?**
+
+A service member whose record appears to show service qualifying for Veterans' preference (for example, there is an indication that the person served in Bosnia in 1996), may be accorded 5 points tentative preference on that basis alone. However, before the person can be appointed, he or she must submit proof of entitlement to preference. That proof may be an amended DD Form 214 showing the award of the Armed Forces Expeditionary Medal (AFEM) for Bosnia in the case of service members who served there and were released prior to enactment of the recent Veterans' preference amendments, or it may be other official documentation showing award of the Armed Forces Expeditionary Medal.
+
+**How are we to know that a Reservist was, in fact, a) called to active duty, and b) served the full period for which called? Don't some Reservists just receive a letter telling them they are being placed on active duty?**
+
+A Reservist will always have orders placing him (or her) on active duty -- (it is the only way the Reservist can be paid). While the individual may also have a letter saying that he or she is being called up, there will always be orders backing this up. Similarly, when the Reservist is released from active duty, he or she will always have separation or demobilization orders.
+
+**Several employees have come to the agency personnel office claiming they should have preference under the new law, but they have no proof of service during the specified period. We are getting ready to issue Reduction In Force (RIF) notices. Should we take the employees' word for it or wait until they have proof?**
+
+The employees cannot be given Veterans' preference without required documentation. The agency should work with the employee and the appropriate military service record organizations to obtain this documentation as soon as possible to avoid having to "rerun" the Reduction In Force at the last minute.
+
+**If our agency has "frozen" personnel actions and issued Reduction In Force notices but the Reduction In Force effective date has not yet arrived, how can we account for any changes in Veterans' preference status?**
+
+Regardless of where you are in the process of carrying out the Reduction In Force, you must correct the Veterans' preference of employees who will now be eligible as a result of the statute. Veterans' preference cannot be "frozen" like qualifications or performance appraisals--it must be corrected right up until the day of the Reduction In Force. If a change in preference results in a different outcome for one or more employees, amended Reduction In Force notices must be issued. If such a change results in a worse offer, the affected employee must be given a full 60/120 day notice period required by regulation. This may require the agency to use a temporary exception to keep one or more employees on the rolls past the Reduction In Force effective date in order to meet this obligation.
+
+**Our agency already completed a Reduction In Force effective November 28, 1997. There is at least one separated employee who would now have Veterans' preference and would not have been separated if we had known about the change in statute. What do we do now?**
+
+If an agency finds that an eligible employee reached for Reduction In Force separation or downgrading effective on or after November 18, 1997, was not provided retention preference consistent with P.L. 105-85, The Office of Personnel Management recommends that the agency take appropriate corrective action.
+An employee not provided appropriate retention preference may appeal the Reduction In Force action to the Merit Systems Protection Board (MSPB). MSPB normally requires the appeal to be filed within 30 days of the Reduction In Force effective date, but Merit Systems Protection Board may, at its option, accept later appeals filed within 30 days of the employee becoming aware of the change.
+If an employee was separated or downgraded by Reduction In Force, the agency should determine whether or not the employee would have been affected differently based on the change in Veterans' preference. If the employee would still be separated or downgraded, the agency should correct the employee's notice. If the employee was separated, the agency should also correct the Reemployment Priority List (RPL) registration (if any) to accurately reflect their Veterans' preference.
+If the corrective action results in a surplus of employees in one or more competitive levels, the agency may have to run a new Reduction In Force. However, the agency cannot retroactively adjust the results of the prior Reduction In Force.
+
+**What if an employee would have been registered as a I-A on the agency's Reemployment Priority List due to the new law, but has been listed as a I-B? What is the agency's obligation to make up for any lost consideration as a result?**
+
+The employee's registration status on the Reemployment Priority List should be corrected immediately so that the employee will be considered as a I-A for the remainder of their time on the Reemployment Priority List. If the agency finds that a lower standing person was selected over the employee, the agency must notify the employee of the selection and their right to appeal to Merit Systems Protection Board. If the employee files a Reemployment Priority List appeal, Merit Systems Protection Board may order a retroactive remedy which could include extending the employee's time period for consideration under the Reemployment Priority List.
 
 ## A Word about Man-Day Tours
-On June 26, 2013, the Supreme Court ruled that Section 3 of the Defense of Marriage Act (DOMA) is
-unconstitutional. As a result of the Supreme Court’s decision, the United States Office of Personnel
-Management (OPM) will now be able to extend certain benefits to Federal employees and annuitants who
-have legally married a spouse of the same sex, regardless of the employee’s or annuitant’s state of residency.
-OPM is currently in the process of updating and revising the website to reflect this change, and will be
-updating this information as soon as possible. Please check back in the coming weeks for updates.
 
-We have received several inquiries concerning the status of "man-day tours." Specifically, agency personnel
-offices have asked, "Are man-day tours considered regular active duty -- and thus qualifying for Veterans'
-preference -- or are they really active duty for training and thereby not qualifying?"
-The questions arose because many Air Force Reservists were placed on these so-called man-day tours -- also
-known as, active duty in support (ADS) -- for only a few days during the Gulf War and Operation Provide
-Comfort (in support of the Kurds) during which they would fly a quick mission to the Gulf, get the Southwest
-Asia Service Medal (SWASM) and come home, then be released. Although they had orders, they received no
-DD Form 214.
-Some agency personnel offices were according these Reservists preference; while other offices were not.
-Some Reservists were awarded preference, then had it withdrawn on the basis that they were only
-performing active duty for training.
-Based on discussions with the Department of Defense, Office of Reserve Affairs and Air Force Instruction
-36-2619 of 7/22/94, which discusses man-day tours, man-day tours are apparently regular active duty tours.
-Therefore, these man-day tours are qualifying for preference if the individual was awarded the SWASM or
-served during the period 8/2/90 to 1/2/92.
-This service is also referred to as MPA man-days because it is funded out of the military appropriation
-account (MPA), an active duty account. Man-days support short-term needs of the active force by
-authorizing no more than 139 days annually to airmen and officers who are typically placed on active duty
-under 10 U.S.C. 12301(d) (ordered to active duty with the individual's consent). This authority should appear
-on the orders. Man-day tours are supposed to accommodate a temporary need for personnel with unique
-skills that cannot be economically met through the active force.
-Based on the above, we have determined that Federal agencies should treat man-day tours as regular active
-duty unless there is some clear indication on the orders that it is active duty for training. Also, please note
-that the SWASM (or any campaign or expeditionary medal) is awarded only for active service in hostile
-areas; a Reservist performing active duty for training would not be eligible for one of these medals.
+On June 26, 2013, the Supreme Court ruled that Section 3 of the Defense of Marriage Act (DOMA) is unconstitutional. As a result of the Supreme Court’s decision, the United States Office of Personnel Management (OPM) will now be able to extend certain benefits to Federal employees and annuitants who have legally married a spouse of the same sex, regardless of the employee’s or annuitant’s state of residency. OPM is currently in the process of updating and revising the website to reflect this change, and will be updating this information as soon as possible. Please check back in the coming weeks for updates.
+
+We have received several inquiries concerning the status of "man-day tours." Specifically, agency personnel offices have asked, "Are man-day tours considered regular active duty -- and thus qualifying for Veterans' preference -- or are they really active duty for training and thereby not qualifying?"
+
+The questions arose because many Air Force Reservists were placed on these so-called man-day tours -- also known as, active duty in support (ADS) -- for only a few days during the Gulf War and Operation Provide Comfort (in support of the Kurds) during which they would fly a quick mission to the Gulf, get the Southwest Asia Service Medal (SWASM) and come home, then be released. Although they had orders, they received no DD Form 214.
+
+Some agency personnel offices were according these Reservists preference; while other offices were not. Some Reservists were awarded preference, then had it withdrawn on the basis that they were only performing active duty for training.
+
+Based on discussions with the Department of Defense, Office of Reserve Affairs and Air Force Instruction 36-2619 of 7/22/94, which discusses man-day tours, man-day tours are apparently regular active duty tours. Therefore, these man-day tours are qualifying for preference if the individual was awarded the SWASM or served during the period 8/2/90 to 1/2/92.
+
+This service is also referred to as MPA man-days because it is funded out of the military appropriation account (MPA), an active duty account. Man-days support short-term needs of the active force by authorizing no more than 139 days annually to airmen and officers who are typically placed on active duty under 10 U.S.C. 12301(d) (ordered to active duty with the individual's consent). This authority should appear on the orders. Man-day tours are supposed to accommodate a temporary need for personnel with unique skills that cannot be economically met through the active force.
+
+Based on the above, we have determined that Federal agencies should treat man-day tours as regular active duty unless there is some clear indication on the orders that it is active duty for training. Also, please note that the SWASM (or any campaign or expeditionary medal) is awarded only for active service in hostile areas; a Reservist performing active duty for training would not be eligible for one of these medals.
 
 ## 10-Point Compensable Disability Preference (CP)
+
 Ten points are added to the passing examination score or rating of:
-* A veteran who served at any time and who has a compensable service-connected disability rating of at
-least 10 percent but less than 30 percent.
+* A veteran who served at any time and who has a compensable service-connected disability rating of at least 10 percent but less than 30 percent.
 
 ## 10-Point 30 Percent Compensable Disability Preference (CPS)
-Ten points are added to the passing examination score or rating of a veteran who served at any time and
-who has a compensable service-connected disability rating of 30 percent or more.
+
+Ten points are added to the passing examination score or rating of a veteran who served at any time and who has a compensable service-connected disability rating of 30 percent or more.
 
 ## 10-Point Disability Preference (XP)
+
 Ten points are added to the passing examination score or rating of:
-* A veteran who served at any time and has a present service-connected disability or is receiving
-compensation, disability retirement benefits, or pension from the military or the Department of
-Veterans Affairs but does not qualify as a CP or CPS; or
+* A veteran who served at any time and has a present service-connected disability or is receiving compensation, disability retirement benefits, or pension from the military or the Department of Veterans Affairs but does not qualify as a CP or CPS; or
 * A veteran who received a Purple Heart.
 
 ## 10-Point Derived Preference (XP)
-Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers
-of veterans as described below. This type of preference is usually referred to as "derived preference" because
-it is based on service of a veteran who is not able to use the preference.
-Both a mother and a spouse (including widow or widower) may be entitled to preference on the basis of the
-same veteran's service if they both meet the requirements. However, neither may receive preference if the
-veteran is living and is qualified for Federal employment.
+
+Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference.
+
+Both a mother and a spouse (including widow or widower) may be entitled to preference on the basis of the same veteran's service if they both meet the requirements. However, neither may receive preference if the veteran is living and is qualified for Federal employment.
 
 ### Spouse
-Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is
-disqualified for a Federal position along the general lines of his or her usual occupation because of a
-service-connected disability. Such a disqualification may be presumed when the veteran is
-unemployed and
-* is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent
-disabled and/or unemployable; or
-* has retired, been separated, or resigned from a civil service position on the basis of a disability that is
-service-connected in origin; or
-* has attempted to obtain a civil service position or other position along the lines of his or her usual
-occupation and has failed to qualify because of a service-connected disability.
-Preference may be allowed in other circumstances but anything less than the above warrants a more careful
-analysis.
 
-NOTE:
-Veterans' preference for spouses is different than the preference the Department of Defense is required by
-law to extend to spouses of active duty members in filling its civilian positions. For more information on that
-program, contact the Department of Defense.
+Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability. Such a disqualification may be presumed when the veteran is unemployed and:
+* is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable; or
+* has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin; or
+* has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability.
+
+Preference may be allowed in other circumstances but anything less than the above warrants a more careful analysis.
+
+**NOTE:**
+Veterans' preference for spouses is different than the preference the Department of Defense is required by law to extend to spouses of active duty members in filling its civilian positions. For more information on that program, contact the Department of Defense.
 
 ### Widow/Widower
-Ten points are added to the passing examination score or rating of the widow or widower of a veteran who
-was not divorced from the veteran, has not remarried, or the remarriage was annulled, and the veteran
-either:
-* served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or
-expedition for which a campaign medal has been authorized; or
-* died while on active duty that included service described immediately above under conditions that
-would not have been the basis for other than an honorable or general discharge.
+
+Ten points are added to the passing examination score or rating of the widow or widower of a veteran who was not divorced from the veteran, has not remarried, or the remarriage was annulled, and the veteran either:
+* served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; or
+* died while on active duty that included service described immediately above under conditions that would not have been the basis for other than an honorable or general discharge.
 
 ### Mother of a deceased veteran
-Ten points are added to the passing examination score or rating of the mother of a veteran who died under
-honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1,
-1955, or in a campaign or expedition for which a campaign medal has been authorized; and
+
+Ten points are added to the passing examination score or rating of the mother of a veteran who died under honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; and
 * she is or was married to the father of the veteran; and
-* she lives with her totally and permanently disabled husband (either the veteran's father or her
-husband through remarriage); or
+* she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or
 * she is widowed, divorced, or separated from the veteran's father and has not remarried; or
-* she remarried but is widowed, divorced, or legally separated from her husband when she claims
-preference.
+* she remarried but is widowed, divorced, or legally separated from her husband when she claims preference.
 
 ### Mother of a disabled veteran
-Ten points are added to the passing examination score or rating of a mother of a living disabled veteran if
-the veteran was separated with an honorable or general discharge from active duty, including training
-service in the Reserves or National Guard, performed at any time and is permanently and totally disabled
-from a service-connected injury or illness; and the mother:
-* is or was married to the father of the veteran; and
-* lives with her totally and permanently disabled husband (either the veteran's father or her husband
-through remarriage); or
-* is widowed, divorced, or separated from the veteran's father and has not remarried; or
-* remarried but is widowed, divorced, or legally separated from her husband when she claims
-preference.
 
-Note: Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5
-U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after
-1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference. 5 U.S.C.
-2108, 3309; 38 U.S.C. 5303A
+Ten points are added to the passing examination score or rating of a mother of a living disabled veteran if the veteran was separated with an honorable or general discharge from active duty, including training service in the Reserves or National Guard, performed at any time and is permanently and totally disabled from a service-connected injury or illness; and the mother:
+* is or was married to the father of the veteran; and
+* lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or
+* is widowed, divorced, or separated from the veteran's father and has not remarried; or
+* remarried but is widowed, divorced, or legally separated from her husband when she claims preference.
+
+**Note:** Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference. 5 U.S.C. 2108, 3309; 38 U.S.C. 5303A
 
 ## A word about the VOW (Veterans Opportunity to Work) Act
-On November 21, 2011, the President signed the VOW (Veterans Opportunity to Work) to Hire Heroes Act of
-2011 (Public Law 112-56). The VOW Act amends chapter 21 of title 5, United States Code (U.S.C.) by adding
-section 2108a, “Treatment of certain individuals as veterans, disabled veterans, and preference eligibles.”
-This new section requires Federal agencies to treat certain active duty service members as preference
-eligibles for purposes of an appointment in the competitive or excepted service, even though the service
-members have not been discharged or released from active duty.
-Because many service members begin their civilian job search prior to being discharged or released from
-active duty service, they may not have a DD form 214, Certificate of Release or Discharge from Active Duty,
-when applying for Federal jobs. The VOW Act was enacted to ensure these individuals do not lose the
-opportunity to be considered for Federal service (and awarded their veterans’ preference entitlements if
-applicable) despite not having a DD form 214 to submit along with their résumés.
-Agencies are required to accept, process, and grant tentative veterans’ preference to those active duty service
-members who submit a certification (in lieu of a DD-form 214) along with their job application materials.
-Agencies must verify the individual meets the definition of ‘preference eligible’ under 5 U.S.C. 2108 prior to
-appointment.
-A “certification” is any written document from the armed forces that certifies the service member is expected
-to be discharged or released from active duty service in the armed forces under honorable conditions within
-120 days after the certification is submitted by the applicant. The certification letter should be on letterhead
-of the appropriate military branch of the service and contain (1) the military service dates including the
-expected discharge or release date; and (2) the character of service.
-If the certification has expired; an agency must request other documentation (e.g., a copy of the DD form
-214) that demonstrates the service member is a preference eligible per 5 U.S.C. 2108, before veterans’
-preference can be awarded.
 
-Based on the OPM Vet Guide for HR Professionals (Chapter: Types of Preference).
+On November 21, 2011, the President signed the VOW (Veterans Opportunity to Work) to Hire Heroes Act of 2011 (Public Law 112-56). The VOW Act amends chapter 21 of title 5, United States Code (U.S.C.) by adding section 2108a, “Treatment of certain individuals as veterans, disabled veterans, and preference eligibles.” This new section requires Federal agencies to treat certain active duty service members as preference eligibles for purposes of an appointment in the competitive or excepted service, even though the service members have not been discharged or released from active duty.
+
+Because many service members begin their civilian job search prior to being discharged or released from active duty service, they may not have a DD form 214, Certificate of Release or Discharge from Active Duty, when applying for Federal jobs. The VOW Act was enacted to ensure these individuals do not lose the opportunity to be considered for Federal service (and awarded their veterans’ preference entitlements if applicable) despite not having a DD form 214 to submit along with their résumés.
+
+Agencies are required to accept, process, and grant tentative veterans’ preference to those active duty service members who submit a certification (in lieu of a DD-form 214) along with their job application materials. Agencies must verify the individual meets the definition of ‘preference eligible’ under 5 U.S.C. 2108 prior to appointment.
+
+A “certification” is any written document from the armed forces that certifies the service member is expected to be discharged or released from active duty service in the armed forces under honorable conditions within 120 days after the certification is submitted by the applicant. The certification letter should be on letterhead of the appropriate military branch of the service and contain (1) the military service dates including the expected discharge or release date; and (2) the character of service.
+
+If the certification has expired; an agency must request other documentation (e.g., a copy of the DD form 214) that demonstrates the service member is a preference eligible per 5 U.S.C. 2108, before veterans’ preference can be awarded.

--- a/preference_types_content.txt
+++ b/preference_types_content.txt
@@ -1,0 +1,312 @@
+Types of Preference
+To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces
+under honorable conditions (i.e., with an honorable or general discharge). As defined in 5 U.S.C. 2101(2),
+"Armed Forces" means the Army, Navy, Air Force, Marine Corps and Coast Guard. The veteran must also be
+eligible under one of the preference categories below (also shown on the Standard Form (SF) 50,
+Notification of Personnel Action).
+Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in
+appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing
+military retired pay until age 60.)
+For non-disabled users, active duty for training by National Guard or Reserve soldiers does not qualify as
+"active duty" for preference.
+For disabled veterans, active duty includes training service in the Reserves or National Guard, per the Merit
+Systems Protection Board decision in Hesse v. Department of the Army, 104 M.S.P.R.647(2007).
+For purposes of this chapter and 5 U.S.C. 2108, "war" means only those armed conflicts declared by
+Congress as war and includes World War II, which covers the period from December 7, 1941, to April 28,
+1952.
+When applying for Federal jobs, eligible veterans should claim preference on their application or resume.
+Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point
+Veteran Preference, and submit the requested documentation.
+The following preference categories and points are based on 5 U.S.C. 2108 and 3309 as modified by a length
+of service requirement in 38 U.S.C. 5303A(d).
+
+0-point Preference (SSP)
+On August 29, 2008, the Hubbard Act was enacted as Public Law 110-317. The Hubbard Act amended the
+eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3).
+Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or
+discharged from a period of active duty from the armed forces, after August 29, 2008, by reason of a “sole
+survivorship discharge.”
+Under the sole survivorship preference, the individual:
+* does not receive veterans’ preference points as other preference eligibles do when the “rule of 3” is applied;
+* is entitled to be listed ahead of non-preference eligibles with the same score on an examination, or listed ahead of non-preference eligibles in the same quality category when agencies are using category rating;
+* is entitled to receive the same pass over rights as other preference eligibles; and
+* is entitled to credit experience in the armed forces to meet the qualification requirements for Federal jobs.
+No points are added to the passing score or rating of a veteran who is the only surviving child in a family in
+which the father or mother or one or more siblings:
+* served in the armed forces, and
+* was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status,
+or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed
+gainfully because of the disability or hospitalization), where
+* the death, status, or disability did not result from the intentional misconduct or willful neglect of the
+parent or sibling and was not incurred during a period of unauthorized absence.
+
+5-Point Preference (TP)
+Five points are added to the passing examination score or rating of a veteran who served:
+* During a war; or
+* During the period April 28, 1952 through July 1, 1955; or
+* For more than 180 consecutive days, other than for training, any part of which occurred after January
+31, 1955, and before October 15, 1976; or
+* During the Gulf War from August 2, 1990, through January 2, 1992; or
+* For more than 180 consecutive days, other than for training, any part of which occurred during the
+period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi
+Freedom; or
+* In a campaign or expedition for which a campaign medal has been authorized. Any Armed Forces
+Expeditionary medal or campaign badge, including El Salvador, Lebanon, Grenada, Panama,
+Southwest Asia, Somalia, and Haiti, qualifies for preference.
+A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began
+active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active
+duty) must have served continuously for 24 months or the full period called or ordered to active duty. The
+24-month service requirement does not apply to 10-point preference eligibles separated for disability
+incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10
+U.S.C. 1171 or 1173.
+
+A word about Gulf War Preference
+The Defense Authorization Act of Fiscal Year 1998 (Public Law 105-85) of November 18, 1997, contains a
+provision (section 1102 of Title XI) which accords Veterans' preference to everyone who served on active
+duty during the period beginning August 2, 1990, and ending January 2, 1992, provided, of course, the
+veteran is otherwise eligible.
+This means that anyone who served on active duty during the Gulf War, regardless of where or for how long,
+is entitled to preference if otherwise eligible (i.e., have been separated under honorable conditions and
+served continuously for a minimum of 24 months or the full period for which called or ordered to active
+duty). This applies not only to candidates seeking employment, but to Federal employees who may be
+affected by reduction in force, as well.
+
+Questions and Answers about Gulf War Preference
+* Public Law 105-85 of November 18, 1997, contains a provision (section 1102 of Title XI)
+which accords Veterans' preference to anyone who served on active duty, anywhere in
+the world, for any length of time between August 2, 1990, and January 2, 1992, provided
+the person is "otherwise eligible." What does "otherwise eligible" mean, here?
+It means the person must have been separated from the service under honorable conditions and have
+served continuously for a minimum of 24 months or the full period for which called or ordered to
+active duty. For example, someone who enlisted in the Army and was serving on active duty when the
+Gulf War broke out on Aug 2, 1990, would have to complete a minimum of 24 months service to be
+eligible for preference. On the other hand a Reservist who was called to active duty for a month and
+spent all his time at the Pentagon before being released would also be eligible. What the law did was to
+add an additional paragraph (C) covering Gulf War veterans to 5 U.S.C. 2108(1) (on who is eligible for
+preference). But, significantly, the law made no other changes to existing law. In particular, it did not
+change paragraph (4) of section 2108 (the Dual Compensation Act of 1973), which severely restricts
+preference entitlement for retired officers at the rank of Major and above. When the Dual
+Compensation Act was under consideration, there was extensive debate in Congress as to who should
+be entitled to preference. Congress basically compromised by giving preference in appointment to
+most retired military members (except for "high-ranking officers" who were not considered to need it),
+but severely limiting preference in RIF for all retired military because they had already served one
+career and should not have preference in the event of layoffs.
+So, "otherwise eligible" means that the individual must be eligible under existing law.
+* Which provision of the new law contains the 24 month service requirement for regular
+military service members on active duty as opposed to reservists who are called or
+ordered to active duty?
+The 24 month service requirement provision is found in Section 5303A of title 38, United States Code
+which defines the minimum active-duty service requirement for those who initially enter active duty
+after September 7, 1980.
+* Can an applicant claim preference based on Gulf War service after January 2, 1992?
+The law specifies that only those on active duty during the period beginning August 2, 1990, and
+ending January 2, 1992, are eligible for preference. Applicants who served on active duty exclusively
+after these dates would have to be in receipt of a campaign badge or expeditionary medal.
+* Are there any plans to extend Veterans' preference to any other groups of individuals
+who served on active duty during times of conflict that may not have served in specific
+theaters of operation?
+We are not aware of any plans to extend Veterans' preference to any other group of individuals.
+* An applicant is claiming preference based on service in Bosnia, but he/she has no DD
+Form 214 to support his claim. Can we give him/her preference?
+A service member whose record appears to show service qualifying for Veterans' preference (for
+example, there is an indication that the person served in Bosnia in 1996), may be accorded 5 points
+tentative preference on that basis alone. However, before the person can be appointed, he or she must
+submit proof of entitlement to preference. That proof may be an amended DD Form 214 showing the
+award of the Armed Forces Expeditionary Medal (AFEM) for Bosnia in the case of service members
+who served there and were released prior to enactment of the recent Veterans' preference
+amendments, or it may be other official documentation showing award of the Armed Forces
+Expeditionary Medal.
+* How are we to know that a Reservist was, in fact, a) called to active duty, and b) served
+the full period for which called? Don't some Reservists just receive a letter telling them
+they are being placed on active duty?
+A Reservist will always have orders placing him (or her) on active duty -- (it is the only way the
+Reservist can be paid). While the individual may also have a letter saying that he or she is being called
+up, there will always be orders backing this up. Similarly, when the Reservist is released from active
+duty, he or she will always have separation or demobilization orders.
+* Several employees have come to the agency personnel office claiming they should have
+preference under the new law, but they have no proof of service during the specified
+period. We are getting ready to issue Reduction In Force (RIF) notices. Should we take
+the employees' word for it or wait until they have proof?
+The employees cannot be given Veterans' preference without required documentation. The agency
+should work with the employee and the appropriate military service record organizations to obtain this
+documentation as soon as possible to avoid having to "rerun" the Reduction In Force at the last
+minute.
+* If our agency has "frozen" personnel actions and issued Reduction In Force notices but
+the Reduction In Force effective date has not yet arrived, how can we account for any
+changes in Veterans' preference status?
+Regardless of where you are in the process of carrying out the Reduction In Force, you must correct
+the Veterans' preference of employees who will now be eligible as a result of the statute. Veterans'
+preference cannot be "frozen" like qualifications or performance appraisals--it must be corrected right
+up until the day of the Reduction In Force. If a change in preference results in a different outcome for
+one or more employees, amended Reduction In Force notices must be issued. If such a change results
+in a worse offer, the affected employee must be given a full 60/120 day notice period required by
+regulation. This may require the agency to use a temporary exception to keep one or more employees
+on the rolls past the Reduction In Force effective date in order to meet this obligation.
+* Our agency already completed a Reduction In Force effective November 28, 1997. There
+is at least one separated employee who would now have Veterans' preference and would
+not have been separated if we had known about the change in statute. What do we do
+now?
+If an agency finds that an eligible employee reached for Reduction In Force separation or downgrading
+effective on or after November 18, 1997, was not provided retention preference consistent with P.L.
+105-85, The Office of Personnel Management recommends that the agency take appropriate corrective
+action.
+An employee not provided appropriate retention preference may appeal the Reduction In Force action
+to the Merit Systems Protection Board (MSPB). MSPB normally requires the appeal to be filed within
+30 days of the Reduction In Force effective date, but Merit Systems Protection Board may, at its
+option, accept later appeals filed within 30 days of the employee becoming aware of the change.
+If an employee was separated or downgraded by Reduction In Force, the agency should determine
+whether or not the employee would have been affected differently based on the change in Veterans'
+preference. If the employee would still be separated or downgraded, the agency should correct the
+employee's notice. If the employee was separated, the agency should also correct the Reemployment
+Priority List (RPL) registration (if any) to accurately reflect their Veterans' preference.
+If the corrective action results in a surplus of employees in one or more competitive levels, the agency
+may have to run a new Reduction In Force. However, the agency cannot retroactively adjust the results
+of the prior Reduction In Force.
+* What if an employee would have been registered as a I-A on the agency's Reemployment
+Priority List due to the new law, but has been listed as a I-B? What is the agency's
+obligation to make up for any lost consideration as a result?
+The employee's registration status on the Reemployment Priority List should be corrected immediately
+so that the employee will be considered as a I-A for the remainder of their time on the Reemployment
+Priority List. If the agency finds that a lower standing person was selected over the employee, the
+agency must notify the employee of the selection and their right to appeal to Merit Systems Protection
+Board. If the employee files a Reemployment Priority List appeal, Merit Systems Protection Board may
+order a retroactive remedy which could include extending the employee's time period for
+consideration under the Reemployment Priority List.
+
+A Word about Man-Day Tours
+On June 26, 2013, the Supreme Court ruled that Section 3 of the Defense of Marriage Act (DOMA) is
+unconstitutional. As a result of the Supreme Court’s decision, the United States Office of Personnel
+Management (OPM) will now be able to extend certain benefits to Federal employees and annuitants who
+have legally married a spouse of the same sex, regardless of the employee’s or annuitant’s state of residency.
+OPM is currently in the process of updating and revising the website to reflect this change, and will be
+updating this information as soon as possible. Please check back in the coming weeks for updates.
+We have received several inquiries concerning the status of "man-day tours." Specifically, agency personnel
+offices have asked, "Are man-day tours considered regular active duty -- and thus qualifying for Veterans'
+preference -- or are they really active duty for training and thereby not qualifying?"
+The questions arose because many Air Force Reservists were placed on these so-called man-day tours -- also
+known as, active duty in support (ADS) -- for only a few days during the Gulf War and Operation Provide
+Comfort (in support of the Kurds) during which they would fly a quick mission to the Gulf, get the Southwest
+Asia Service Medal (SWASM) and come home, then be released. Although they had orders, they received no
+DD Form 214.
+Some agency personnel offices were according these Reservists preference; while other offices were not.
+Some Reservists were awarded preference, then had it withdrawn on the basis that they were only
+performing active duty for training.
+Based on discussions with the Department of Defense, Office of Reserve Affairs and Air Force Instruction
+36-2619 of 7/22/94, which discusses man-day tours, man-day tours are apparently regular active duty tours.
+Therefore, these man-day tours are qualifying for preference if the individual was awarded the SWASM or
+served during the period 8/2/90 to 1/2/92.
+This service is also referred to as MPA man-days because it is funded out of the military appropriation
+account (MPA), an active duty account. Man-days support short-term needs of the active force by
+authorizing no more than 139 days annually to airmen and officers who are typically placed on active duty
+under 10 U.S.C. 12301(d) (ordered to active duty with the individual's consent). This authority should appear
+on the orders. Man-day tours are supposed to accommodate a temporary need for personnel with unique
+skills that cannot be economically met through the active force.
+Based on the above, we have determined that Federal agencies should treat man-day tours as regular active
+duty unless there is some clear indication on the orders that it is active duty for training. Also, please note
+that the SWASM (or any campaign or expeditionary medal) is awarded only for active service in hostile
+areas; a Reservist performing active duty for training would not be eligible for one of these medals.
+
+10-Point Compensable Disability Preference (CP)
+Ten points are added to the passing examination score or rating of:
+* A veteran who served at any time and who has a compensable service-connected disability rating of at
+least 10 percent but less than 30 percent.
+
+10-Point 30 Percent Compensable Disability Preference (CPS)
+Ten points are added to the passing examination score or rating of a veteran who served at any time and
+who has a compensable service-connected disability rating of 30 percent or more.
+
+10-Point Disability Preference (XP)
+Ten points are added to the passing examination score or rating of:
+* A veteran who served at any time and has a present service-connected disability or is receiving
+compensation, disability retirement benefits, or pension from the military or the Department of
+Veterans Affairs but does not qualify as a CP or CPS; or
+* A veteran who received a Purple Heart.
+
+10-Point Derived Preference (XP)
+Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers
+of veterans as described below. This type of preference is usually referred to as "derived preference" because
+it is based on service of a veteran who is not able to use the preference.
+Both a mother and a spouse (including widow or widower) may be entitled to preference on the basis of the
+same veteran's service if they both meet the requirements. However, neither may receive preference if the
+veteran is living and is qualified for Federal employment.
+
+Spouse
+Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is
+disqualified for a Federal position along the general lines of his or her usual occupation because of a
+service-connected disability. Such a disqualification may be presumed when the veteran is
+unemployed and
+* is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent
+disabled and/or unemployable; or
+* has retired, been separated, or resigned from a civil service position on the basis of a disability that is
+service-connected in origin; or
+* has attempted to obtain a civil service position or other position along the lines of his or her usual
+occupation and has failed to qualify because of a service-connected disability.
+Preference may be allowed in other circumstances but anything less than the above warrants a more careful
+analysis.
+
+NOTE:
+Veterans' preference for spouses is different than the preference the Department of Defense is required by
+law to extend to spouses of active duty members in filling its civilian positions. For more information on that
+program, contact the Department of Defense.
+
+Widow/Widower
+Ten points are added to the passing examination score or rating of the widow or widower of a veteran who
+was not divorced from the veteran, has not remarried, or the remarriage was annulled, and the veteran
+either:
+* served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or
+expedition for which a campaign medal has been authorized; or
+* died while on active duty that included service described immediately above under conditions that
+would not have been the basis for other than an honorable or general discharge.
+
+Mother of a deceased veteran
+Ten points are added to the passing examination score or rating of the mother of a veteran who died under
+honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1,
+1955, or in a campaign or expedition for which a campaign medal has been authorized; and
+* she is or was married to the father of the veteran; and
+* she lives with her totally and permanently disabled husband (either the veteran's father or her
+husband through remarriage); or
+* she is widowed, divorced, or separated from the veteran's father and has not remarried; or
+* she remarried but is widowed, divorced, or legally separated from her husband when she claims
+preference.
+
+Mother of a disabled veteran
+Ten points are added to the passing examination score or rating of a mother of a living disabled veteran if
+the veteran was separated with an honorable or general discharge from active duty, including training
+service in the Reserves or National Guard, performed at any time and is permanently and totally disabled
+from a service-connected injury or illness; and the mother:
+* is or was married to the father of the veteran; and
+* lives with her totally and permanently disabled husband (either the veteran's father or her husband
+through remarriage); or
+* is widowed, divorced, or separated from the veteran's father and has not remarried; or
+* remarried but is widowed, divorced, or legally separated from her husband when she claims
+preference.
+
+Note: Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5
+U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after
+1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference. 5 U.S.C.
+2108, 3309; 38 U.S.C. 5303A
+
+A word about the VOW (Veterans Opportunity to Work) Act
+On November 21, 2011, the President signed the VOW (Veterans Opportunity to Work) to Hire Heroes Act of
+2011 (Public Law 112-56). The VOW Act amends chapter 21 of title 5, United States Code (U.S.C.) by adding
+section 2108a, “Treatment of certain individuals as veterans, disabled veterans, and preference eligibles.”
+This new section requires Federal agencies to treat certain active duty service members as preference
+eligibles for purposes of an appointment in the competitive or excepted service, even though the service
+members have not been discharged or released from active duty.
+Because many service members begin their civilian job search prior to being discharged or released from
+active duty service, they may not have a DD form 214, Certificate of Release or Discharge from Active Duty,
+when applying for Federal jobs. The VOW Act was enacted to ensure these individuals do not lose the
+opportunity to be considered for Federal service (and awarded their veterans’ preference entitlements if
+applicable) despite not having a DD form 214 to submit along with their résumés.
+Agencies are required to accept, process, and grant tentative veterans’ preference to those active duty service
+members who submit a certification (in lieu of a DD-form 214) along with their job application materials.
+Agencies must verify the individual meets the definition of ‘preference eligible’ under 5 U.S.C. 2108 prior to
+appointment.
+A “certification” is any written document from the armed forces that certifies the service member is expected
+to be discharged or released from active duty service in the armed forces under honorable conditions within
+120 days after the certification is submitted by the applicant. The certification letter should be on letterhead
+of the appropriate military branch of the service and contain (1) the military service dates including the
+expected discharge or release date; and (2) the character of service.
+If the certification has expired; an agency must request other documentation (e.g., a copy of the DD form
+214) that demonstrates the service member is a preference eligible per 5 U.S.C. 2108, before veterans’
+preference can be awarded.

--- a/rif-procedures.md
+++ b/rif-procedures.md
@@ -1,119 +1,77 @@
 ---
 layout: page
-title: Veterans' Preference in RIF Procedures
+title: RIF Procedures
 permalink: /rif-procedures/
 ---
 
-Veterans have advantages over nonveterans in a reduction in force (RIF). Also, special provisions apply in
-determining whether retired military members receive preference in RIF and whether their military service
-is counted. This chapter deals with RIF in the competitive service; some, but not all, of the provisions apply
-in the excepted service.
+## Veterans' Preference in Reduction in Force
+
+Veterans have advantages over nonveterans in a reduction in force (RIF). Also, special provisions apply in determining whether retired military members receive preference in RIF and whether their military service is counted. This chapter deals with RIF in the competitive service; some, but not all, of the provisions apply in the excepted service.
 
 ## Eligibility for Veterans' Preference in RIF
-Determinations of Veterans' preference eligibility are made in accordance with the information under
-Preference in Appointments in Chapter 2, except that a retired member of a uniformed service must
-meet an additional condition to be considered a preference eligible for RIF purposes. This condition differs
-depending on the rank at which the individual retired from the uniformed service. Uniformed service as
-defined in 5 United States Code (U.S.C.) 2101 means the Armed Forces, the commissioned corps of the
-Public Health Service, and the commissioned corps of the National Oceanic and Atmospheric
-Administration.
+
+Determinations of Veterans' preference eligibility are made in accordance with the information under Preference in Appointments in Chapter 2, except that a retired member of a uniformed service must meet an additional condition to be considered a preference eligible for RIF purposes. This condition differs depending on the rank at which the individual retired from the uniformed service. Uniformed service as defined in 5 United States Code (U.S.C.) 2101 means the Armed Forces, the commissioned corps of the Public Health Service, and the commissioned corps of the National Oceanic and Atmospheric Administration.
 
 Retirees below the rank of major (or equivalent) get preference if:
-* Retirement from the uniformed service is based on disability that either resulted from injury or
-disease received in the line of duty as a direct result of armed conflict, or was caused by an
-instrumentality of war and was incurred in the line of duty during a period of war as defined in section
-101(11) of title 38, U. S. C. "Period of war" includes World War II, the Korean conflict, Vietnam era, the
-Persian Gulf War, or the period beginning on the date of any future declaration of war by the Congress
-and ending on the date prescribed by Presidential proclamation or concurrent resolution of the
-Congress; or
-* The employee's retired pay from a uniformed service is not based on 20 or more years of full-time
-active service, regardless of when performed but not including periods of active duty for training; or
-* The employee has been continuously employed in a position covered by the 5 U.S.C. chapter 35 since
-November 30, 1964, without a break in service of more than 30 days.
+* Retirement from the uniformed service is based on disability that either resulted from injury or disease received in the line of duty as a direct result of armed conflict, or was caused by an instrumentality of war and was incurred in the line of duty during a period of war as defined in section 101(11) of title 38, U. S. C. "Period of war" includes World War II, the Korean conflict, Vietnam era, the Persian Gulf War, or the period beginning on the date of any future declaration of war by the Congress and ending on the date prescribed by Presidential proclamation or concurrent resolution of the Congress; or
+* The employee's retired pay from a uniformed service is not based on 20 or more years of full-time active service, regardless of when performed but not including periods of active duty for training; or
+* The employee has been continuously employed in a position covered by the 5 U.S.C. chapter 35 since November 30, 1964, without a break in service of more than 30 days.
 
-Retirees at or above the rank of major (or equivalent) get preference if they are disabled veterans as
-defined in 5 U.S.C. 2108(2) (includes XP, CP, and CPS) and also meet one of the criteria above for a person
-retired below the rank of major.
+Retirees at or above the rank of major (or equivalent) get preference if they are disabled veterans as defined in 5 U.S.C. 2108(2) (includes XP, CP, and CPS) and also meet one of the criteria above for a person retired below the rank of major.
 
-A preference eligible who at age 60 becomes eligible as a reservist for retired pay under 10 U.S.C. chapter
-1223 (previously chapter 67) and who retires at or above the rank of major (or equivalent) is considered a
-preference eligible for RIF purposes at age 60 only if he or she is a disabled veteran as defined in 5 U.S.C.
-2108(2) (includes categories XP, CP, and CPS). Receipt of retired pay under chapter 1223 meets the
-requirement that retired pay not be based on 20 or more years of full-time active service. Eligibility for
-retired reservist pay occurs at age 60; up to that time a reservist is not considered a retired member of a
-uniformed service and, if otherwise eligible, is a preference eligible for reduction in force purposes.
+A preference eligible who at age 60 becomes eligible as a reservist for retired pay under 10 U.S.C. chapter 1223 (previously chapter 67) and who retires at or above the rank of major (or equivalent) is considered a preference eligible for RIF purposes at age 60 only if he or she is a disabled veteran as defined in 5 U.S.C. 2108(2) (includes categories XP, CP, and CPS). Receipt of retired pay under chapter 1223 meets the requirement that retired pay not be based on 20 or more years of full-time active service. Eligibility for retired reservist pay occurs at age 60; up to that time a reservist is not considered a retired member of a uniformed service and, if otherwise eligible, is a preference eligible for reduction in force purposes.
+
 5 U.S.C. 3501, 3502; 5 CFR 351.501
 
 ## RIF Retention Standing
-Employees are ranked on retention registers for competitive levels (groups of similar jobs) based on four
-factors: tenure, Veterans' preference, length of service, and performance.
-First they are placed in Tenure Group I, II, or III, depending on their type of appointment. Within each
-group, they are placed in a subgroup based on their veteran status:
-* Subgroup AD includes each preference eligible who has a compensable service-connected disability of
-30 percent or more.
-* Subgroup A includes all other preference eligibles not in Subgroup AD, including employees with
-derived preference (see Chapter 2).
+
+Employees are ranked on retention registers for competitive levels (groups of similar jobs) based on four factors: tenure, Veterans' preference, length of service, and performance.
+
+First they are placed in Tenure Group I, II, or III, depending on their type of appointment. Within each group, they are placed in a subgroup based on their veteran status:
+* Subgroup AD includes each preference eligible who has a compensable service-connected disability of 30 percent or more.
+* Subgroup A includes all other preference eligibles not in Subgroup AD, including employees with derived preference (see Chapter 2).
 * Subgroup B includes all employees not eligible for Veterans' preference.
 
-Within each subgroup, employees are ranked in descending order by the length of their creditable Federal
-civilian and military service, augmented by additional service according to the level of their performance
-ratings.
-When a position in a competitive level is abolished, the employee affected (released from the competitive
-level) is the one who stands the lowest on the retention register. Because veterans are listed ahead of
-nonveterans within each tenure group, they are the last to be affected by a RIF action.
-Employees are not subject to a reduction in force while they are serving in the uniformed services. After
-return from active duty, they are protected from RIF action. If they served for more than 180 days, they may
-not be separated by RIF for 1 year after their return. If they served for more than 30 but less than 181 days,
-they may not be separated by RIF for 6 months.
+Within each subgroup, employees are ranked in descending order by the length of their creditable Federal civilian and military service, augmented by additional service according to the level of their performance ratings.
+
+When a position in a competitive level is abolished, the employee affected (released from the competitive level) is the one who stands the lowest on the retention register. Because veterans are listed ahead of nonveterans within each tenure group, they are the last to be affected by a RIF action.
+
+Employees are not subject to a reduction in force while they are serving in the uniformed services. After return from active duty, they are protected from RIF action. If they served for more than 180 days, they may not be separated by RIF for 1 year after their return. If they served for more than 30 but less than 181 days, they may not be separated by RIF for 6 months.
+
 5 U.S.C. 3502; 5 CFR 351.404(a), 351.606(a), and Subpart E
 
 ## Assignment Rights (Bump and Retreat)
-When an employee in Tenure Group I or II with a minimally successful performance rating is released from
-a competitive level within the competitive area where the RIF takes place, he or she is entitled under certain
-circumstances to displace another employee with lower retention standing. The superior standing of
-preference eligibles gives them an advantage in being retained over other employees. These displacement
-actions apply to the competitive service although an agency may, at its discretion, adopt similar provisions
-for its excepted employees.
+
+When an employee in Tenure Group I or II with a minimally successful performance rating is released from a competitive level within the competitive area where the RIF takes place, he or she is entitled under certain circumstances to displace another employee with lower retention standing. The superior standing of preference eligibles gives them an advantage in being retained over other employees. These displacement actions apply to the competitive service although an agency may, at its discretion, adopt similar provisions for its excepted employees.
 
 ### Bumping
-An employee may bump in the same competitive area to a position no more than three grades (or
-grade intervals) lower than the position from which the employee is released that is held by an
-employee in a lower group or subgroup.
+
+An employee may bump in the same competitive area to a position no more than three grades (or grade intervals) lower than the position from which the employee is released that is held by an employee in a lower group or subgroup.
 
 ### Retreating
-An employee may retreat in the same competitive area to a position held by another employee with
-lower retention standing in the same tenure group and subgroup that is essentially identical to one
-previously held by the retreating employee and is no more than three grades (or grade
-intervals) lower than the position from which the employee is released.
-A preference eligible with a compensable service-connected disability of 30 percent or more
-may retreat to a position up to five grades (or grade intervals) lower.
-An employee with an unacceptable performance rating has no right to bump or retreat.
-An employee with a performance rating of minimally successful may retreat only to positions held by an
-employee with the same or lower rating.
 
-### Qualifications
-In reviewing the qualifications of a preference eligible to determine assignment rights in a RIF, the agency
-must waive requirements as described under Physical Qualifications in Chapter 2. If the veteran involved
-has a 30 percent or more compensable disability, special procedures apply as described under
-Disqualification of 30 Percent or more Disabled Veterans in Chapter 2. OPM must approve the sufficiency
-of the agency's reasons to medically disqualify a 30 percent or more compensably disabled veteran for
-assignment to another position in a RIF.
+An employee may retreat in the same competitive area to a position held by another employee with lower retention standing in the same tenure group and subgroup that is essentially identical to one previously held by the retreating employee and is no more than three grades (or grade intervals) lower than the position from which the employee is released.
+
+A preference eligible with a compensable service-connected disability of 30 percent or more may retreat to a position up to five grades (or grade intervals) lower.
+
+An employee with an unacceptable performance rating has no right to bump or retreat.
+
+An employee with a performance rating of minimally successful may retreat only to positions held by an employee with the same or lower rating.
+
+## Qualifications
+
+In reviewing the qualifications of a preference eligible to determine assignment rights in a RIF, the agency must waive requirements as described under Physical Qualifications in Chapter 2. If the veteran involved has a 30 percent or more compensable disability, special procedures apply as described under Disqualification of 30 Percent or more Disabled Veterans in Chapter 2. OPM must approve the sufficiency of the agency's reasons to medically disqualify a 30 percent or more compensably disabled veteran for assignment to another position in a RIF.
+
 5 U.S.C. 3502, 3504; 5 CFR Part 351, Subpart G, and Part 339
 
 ## Appeal of RIF Actions
-An employee who has been furloughed, separated, or demoted by RIF action has the right to appeal the
-action to the Merit Systems Protection Board except when a negotiated procedure must be used. Assignment
-to a position at the employee's same grade or representative rate is not appealable. Appeals must be filed
-during the period beginning on the day after the effective date of the RIF action and ending 30 days after the
-effective date. Time limits for filing a grievance under a negotiated procedure are contained in the negotiated
-agreement.
+
+An employee who has been furloughed, separated, or demoted by RIF action has the right to appeal the action to the Merit Systems Protection Board except when a negotiated procedure must be used. Assignment to a position at the employee's same grade or representative rate is not appealable. Appeals must be filed during the period beginning on the day after the effective date of the RIF action and ending 30 days after the effective date. Time limits for filing a grievance under a negotiated procedure are contained in the negotiated agreement.
+
 5 CFR 351.901, Part 1201
 
 ## Reemployment Priority for Separated Employees
-After a RIF, separated competitive service employees in tenure groups I and II are listed on the agency's
-Reemployment Priority List. The agency generally may not hire from most outside sources when qualified
-employees are on the List. In hiring from the List, preference eligibles receive preference over other
-employees. Excepted service employees separated by RIF receive similar priority in excepted employment.
-5 U.S.C. 3315; 5 CFR Part 330, Subpart B, and Part 302
 
-Based on the OPM Vet Guide for HR Professionals (Chapter: Veterans' Preference in Reduction in Force).
+After a RIF, separated competitive service employees in tenure groups I and II are listed on the agency's Reemployment Priority List. The agency generally may not hire from most outside sources when qualified employees are on the List. In hiring from the List, preference eligibles receive preference over other employees. Excepted service employees separated by RIF receive similar priority in excepted employment.
+
+5 U.S.C. 3315; 5 CFR Part 330, Subpart B, and Part 302

--- a/rif_procedures_content.txt
+++ b/rif_procedures_content.txt
@@ -1,0 +1,106 @@
+Veterans' Preference in Reduction in Force
+Veterans have advantages over nonveterans in a reduction in force (RIF). Also, special provisions apply in
+determining whether retired military members receive preference in RIF and whether their military service
+is counted. This chapter deals with RIF in the competitive service; some, but not all, of the provisions apply
+in the excepted service.
+
+Eligibility for Veterans' Preference in RIF
+Determinations of Veterans' preference eligibility are made in accordance with the information under
+Preference in Appointments in Chapter 2, except that a retired member of a uniformed service must
+meet an additional condition to be considered a preference eligible for RIF purposes. This condition differs
+depending on the rank at which the individual retired from the uniformed service. Uniformed service as
+defined in 5 United States Code (U.S.C.) 2101 means the Armed Forces, the commissioned corps of the
+Public Health Service, and the commissioned corps of the National Oceanic and Atmospheric
+Administration.
+Retirees below the rank of major (or equivalent) get preference if:
+* Retirement from the uniformed service is based on disability that either resulted from injury or
+disease received in the line of duty as a direct result of armed conflict, or was caused by an
+instrumentality of war and was incurred in the line of duty during a period of war as defined in section
+101(11) of title 38, U. S. C. "Period of war" includes World War II, the Korean conflict, Vietnam era, the
+Persian Gulf War, or the period beginning on the date of any future declaration of war by the Congress
+and ending on the date prescribed by Presidential proclamation or concurrent resolution of the
+Congress; or
+* The employee's retired pay from a uniformed service is not based on 20 or more years of full-time
+active service, regardless of when performed but not including periods of active duty for training; or
+* The employee has been continuously employed in a position covered by the 5 U.S.C. chapter 35 since
+November 30, 1964, without a break in service of more than 30 days.
+Retirees at or above the rank of major (or equivalent) get preference if they are disabled veterans as
+defined in 5 U.S.C. 2108(2) (includes XP, CP, and CPS) and also meet one of the criteria above for a person
+retired below the rank of major.
+A preference eligible who at age 60 becomes eligible as a reservist for retired pay under 10 U.S.C. chapter
+1223 (previously chapter 67) and who retires at or above the rank of major (or equivalent) is considered a
+preference eligible for RIF purposes at age 60 only if he or she is a disabled veteran as defined in 5 U.S.C.
+2108(2) (includes categories XP, CP, and CPS). Receipt of retired pay under chapter 1223 meets the
+requirement that retired pay not be based on 20 or more years of full-time active service. Eligibility for
+retired reservist pay occurs at age 60; up to that time a reservist is not considered a retired member of a
+uniformed service and, if otherwise eligible, is a preference eligible for reduction in force purposes.
+5 U.S.C. 3501, 3502; 5 CFR 351.501
+
+RIF Retention Standing
+Employees are ranked on retention registers for competitive levels (groups of similar jobs) based on four
+factors: tenure, Veterans' preference, length of service, and performance.
+First they are placed in Tenure Group I, II, or III, depending on their type of appointment. Within each
+group, they are placed in a subgroup based on their veteran status:
+* Subgroup AD includes each preference eligible who has a compensable service-connected disability of
+30 percent or more.
+* Subgroup A includes all other preference eligibles not in Subgroup AD, including employees with
+derived preference (see Chapter 2).
+* Subgroup B includes all employees not eligible for Veterans' preference.
+Within each subgroup, employees are ranked in descending order by the length of their creditable Federal
+civilian and military service, augmented by additional service according to the level of their performance
+ratings.
+When a position in a competitive level is abolished, the employee affected (released from the competitive
+level) is the one who stands the lowest on the retention register. Because veterans are listed ahead of
+nonveterans within each tenure group, they are the last to be affected by a RIF action.
+Employees are not subject to a reduction in force while they are serving in the uniformed services. After
+return from active duty, they are protected from RIF action. If they served for more than 180 days, they may
+not be separated by RIF for 1 year after their return. If they served for more than 30 but less than 181 days,
+they may not be separated by RIF for 6 months.
+5 U.S.C. 3502; 5 CFR 351.404(a), 351.606(a), and Subpart E
+
+Assignment Rights (Bump and Retreat)
+When an employee in Tenure Group I or II with a minimally successful performance rating is released from
+a competitive level within the competitive area where the RIF takes place, he or she is entitled under certain
+circumstances to displace another employee with lower retention standing. The superior standing of
+preference eligibles gives them an advantage in being retained over other employees. These displacement
+actions apply to the competitive service although an agency may, at its discretion, adopt similar provisions
+for its excepted employees.
+Bumping
+An employee may bump in the same competitive area to a position no more than three grades (or
+grade intervals) lower than the position from which the employee is released that is held by an
+employee in a lower group or subgroup.
+Retreating
+An employee may retreat in the same competitive area to a position held by another employee with
+lower retention standing in the same tenure group and subgroup that is essentially identical to one
+previously held by the retreating employee and is no more than three grades (or grade
+intervals) lower than the position from which the employee is released.
+A preference eligible with a compensable service-connected disability of 30 percent or more
+may retreat to a position up to five grades (or grade intervals) lower.
+An employee with an unacceptable performance rating has no right to bump or retreat.
+An employee with a performance rating of minimally successful may retreat only to positions held by an
+employee with the same or lower rating.
+
+Qualifications
+In reviewing the qualifications of a preference eligible to determine assignment rights in a RIF, the agency
+must waive requirements as described under Physical Qualifications in Chapter 2. If the veteran involved
+has a 30 percent or more compensable disability, special procedures apply as described under
+Disqualification of 30 Percent or more Disabled Veterans in Chapter 2. OPM must approve the sufficiency
+of the agency's reasons to medically disqualify a 30 percent or more compensably disabled veteran for
+assignment to another position in a RIF.
+5 U.S.C. 3502, 3504; 5 CFR Part 351, Subpart G, and Part 339
+
+Appeal of RIF Actions
+An employee who has been furloughed, separated, or demoted by RIF action has the right to appeal the
+action to the Merit Systems Protection Board except when a negotiated procedure must be used. Assignment
+to a position at the employee's same grade or representative rate is not appealable. Appeals must be filed
+during the period beginning on the day after the effective date of the RIF action and ending 30 days after the
+effective date. Time limits for filing a grievance under a negotiated procedure are contained in the negotiated
+agreement.
+5 CFR 351.901, Part 1201
+
+Reemployment Priority for Separated Employees
+After a RIF, separated competitive service employees in tenure groups I and II are listed on the agency's
+Reemployment Priority List. The agency generally may not hire from most outside sources when qualified
+employees are on the List. In hiring from the List, preference eligibles receive preference over other
+employees. Excepted service employees separated by RIF receive similar priority in excepted employment.
+5 U.S.C. 3315; 5 CFR Part 330, Subpart B, and Part 302

--- a/special-authorities.md
+++ b/special-authorities.md
@@ -4,273 +4,177 @@ title: Special Appointing Authorities for Veterans
 permalink: /special-authorities/
 ---
 
+## Special Appointing Authorities for Veterans
+
 ## Veterans Recruitment Appointment (VRA) Authority
-The VRA is a special authority by which agencies can, if they wish, appoint eligible veterans without
-competition to positions at any grade level through General Schedule (GS) 11 or equivalent. (The promotion
-potential of the position is not a factor.) VRA appointees are hired under excepted appointments to positions
-that are otherwise in the competitive service. There is no limitation to the number of VRA appointments an
-individual may receive, provided the individual is otherwise eligible.
-If the agency has more than one VRA candidate for the same job and one (or more) is a preference eligible,
-the agency must apply the Veterans' preference procedures prescribed in 5 CFR Part 302 in making VRA
-appointments. A veteran who is eligible for a VRA appointment is not automatically eligible for Veterans'
-preference.
-After two years of satisfactory service, the agency must convert the veteran to career or career-conditional
-appointment, as appropriate.
+
+The VRA is a special authority by which agencies can, if they wish, appoint eligible veterans without competition to positions at any grade level through General Schedule (GS) 11 or equivalent. (The promotion potential of the position is not a factor.) VRA appointees are hired under excepted appointments to positions that are otherwise in the competitive service. There is no limitation to the number of VRA appointments an individual may receive, provided the individual is otherwise eligible.
+
+If the agency has more than one VRA candidate for the same job and one (or more) is a preference eligible, the agency must apply the Veterans' preference procedures prescribed in 5 CFR Part 302 in making VRA appointments. A veteran who is eligible for a VRA appointment is not automatically eligible for Veterans' preference.
+
+After two years of satisfactory service, the agency must convert the veteran to career or career-conditional appointment, as appropriate.
 
 ### Eligibility Criteria:
-The Jobs for Veterans Act, Public Law 107-288, amended title 38 U.S.C. 4214 by making a major change in
-the eligibility criteria for obtaining a Veterans Recruitment Appointment (VRA). Those who are eligible:
-* Disabled veterans; or
-* Veterans who served on active duty in the Armed Forces during a war, or in a campaign or expedition
-for which a campaign badge has been authorized; or
-* Veterans who, while serving on active duty in the Armed Forces, participated in a United States
-military operation for which an Armed Forces Service Medal was awarded; or
-* Recently separated veterans.
-Veterans claiming eligibility on the basis of service in a campaign or expedition for which a medal was
-awarded must be in receipt of the campaign badge or medal.
-In addition to meeting the criteria above, eligible veterans must have been separated under honorable
-conditions (i.e., the individual must have received either an honorable or general discharge).
 
-Note: Under the eligibility criteria, not all 5-point preference eligible veterans may be eligible for a VRA
-appointment. For example, a veteran who served during the Vietnam era (i.e., for more than 180 consecutive
-days, after January 31, 1955, and before October 15, 1976) but did not receive a service-connected disability
-or an Armed Forces Service medal or campaign or expeditionary medal would be entitled to 5 pt. veterans'
-preference. This veteran, however, would not be eligible for a VRA appointment under the above criteria.
-As another example, a veteran who served during the Gulf War from August 2, 1990, through January 2,
-1992, would be eligible for veterans' preference solely on the basis of that service. However, service during
-that time period, in and of itself, does not confer VRA eligibility on the veteran unless one of the above VRA
-eligibility criteria is met.
-Lastly, if an agency has 2 or more VRA candidates and 1 or more is a preference eligible, the agency must
-apply Veterans' preference. For example, one applicant is VRA eligible on the basis of receiving an Armed
-Forces Service Medal (this medal does not confer veterans' preference eligibility). The second applicant is
-VRA eligible on the basis of being a disabled veteran (which does confer veterans' preference eligibility). In
-this example, both individuals are VRA eligible but only one of them is eligible for Veterans' preference. As a
-result, agencies must apply the procedures of 5 CFR 302 when considering VRA candidates for appointment.
+The Jobs for Veterans Act, Public Law 107-288, amended title 38 U.S.C. 4214 by making a major change in the eligibility criteria for obtaining a Veterans Recruitment Appointment (VRA). Those who are eligible:
+* Disabled veterans; or
+* Veterans who served on active duty in the Armed Forces during a war, or in a campaign or expedition for which a campaign badge has been authorized; or
+* Veterans who, while serving on active duty in the Armed Forces, participated in a United States military operation for which an Armed Forces Service Medal was awarded; or
+* Recently separated veterans.
+
+Veterans claiming eligibility on the basis of service in a campaign or expedition for which a medal was awarded must be in receipt of the campaign badge or medal.
+
+In addition to meeting the criteria above, eligible veterans must have been separated under honorable conditions (i.e., the individual must have received either an honorable or general discharge).
+
+**Note:** Under the eligibility criteria, not all 5-point preference eligible veterans may be eligible for a VRA appointment. For example, a veteran who served during the Vietnam era (i.e., for more than 180 consecutive days, after January 31, 1955, and before October 15, 1976) but did not receive a service-connected disability or an Armed Forces Service medal or campaign or expeditionary medal would be entitled to 5 pt. veterans' preference. This veteran, however, would not be eligible for a VRA appointment under the above criteria.
+
+As another example, a veteran who served during the Gulf War from August 2, 1990, through January 2, 1992, would be eligible for veterans' preference solely on the basis of that service. However, service during that time period, in and of itself, does not confer VRA eligibility on the veteran unless one of the above VRA eligibility criteria is met.
+
+Lastly, if an agency has 2 or more VRA candidates and 1 or more is a preference eligible, the agency must apply Veterans' preference. For example, one applicant is VRA eligible on the basis of receiving an Armed Forces Service Medal (this medal does not confer veterans' preference eligibility). The second applicant is VRA eligible on the basis of being a disabled veteran (which does confer veterans' preference eligibility). In this example, both individuals are VRA eligible but only one of them is eligible for Veterans' preference. As a result, agencies must apply the procedures of 5 CFR 302 when considering VRA candidates for appointment.
 
 ### Making Appointments
-Ordinarily, an agency may simply appoint any VRA eligible who meets the basic qualifications requirements
-for the position to be filled without having to announce the job or rate and rank applicants. However, as
-noted, Veterans' preference applies in making appointments under the VRA authority. This means that if an
-agency has 2 or more VRA candidates and 1 or more is a preference eligible, the agency must apply Veterans'
-preference. Furthermore, an agency must consider all VRA candidates on file who are qualified for the
-position and could reasonably expect to be considered for the opportunity; it cannot place VRA candidates in
-separate groups or consider them as separate sources in order to avoid applying preference or to reach a
-favored candidate.
+
+Ordinarily, an agency may simply appoint any VRA eligible who meets the basic qualifications requirements for the position to be filled without having to announce the job or rate and rank applicants. However, as noted, Veterans' preference applies in making appointments under the VRA authority. This means that if an agency has 2 or more VRA candidates and 1 or more is a preference eligible, the agency must apply Veterans' preference. Furthermore, an agency must consider all VRA candidates on file who are qualified for the position and could reasonably expect to be considered for the opportunity; it cannot place VRA candidates in separate groups or consider them as separate sources in order to avoid applying preference or to reach a favored candidate.
 
 ### Terms and Conditions of Employment
-A VRA appointee may be promoted, demoted, reassigned, or transferred in the same way as a career
-employee. As with other competitive service employees, the time in grade requirement applies to the
-promotion of VRAs. If a VRA-eligible employee is qualified for a higher grade, an agency may, at its
-discretion, give the employee a new VRA appointment at a higher grade up through GS-11 (or equivalent)
-without regard to time-in-grade.
-Agencies must establish a training or education program for any VRA appointee who has less than 15 years
-of education. This program should meet the needs of both the agency and the employee.
+
+A VRA appointee may be promoted, demoted, reassigned, or transferred in the same way as a career employee. As with other competitive service employees, the time in grade requirement applies to the promotion of VRAs. If a VRA-eligible employee is qualified for a higher grade, an agency may, at its discretion, give the employee a new VRA appointment at a higher grade up through GS-11 (or equivalent) without regard to time-in-grade.
+
+Agencies must establish a training or education program for any VRA appointee who has less than 15 years of education. This program should meet the needs of both the agency and the employee.
 
 ### Appeal Rights
-During their first year of employment, VRA appointees have the same limited appeal rights as competitive
-service probationers, but otherwise they have the appeal rights of excepted service employees. This means
-that VRA employees who are preference eligibles have adverse action protections after one year (see Chapter
-7). VRA's who are not preference eligibles do not get this protection until they have completed 2 years of
-current continuous employment in the same or similar position.
+
+During their first year of employment, VRA appointees have the same limited appeal rights as competitive service probationers, but otherwise they have the appeal rights of excepted service employees. This means that VRA employees who are preference eligibles have adverse action protections after one year (see Chapter 7). VRA's who are not preference eligibles do not get this protection until they have completed 2 years of current continuous employment in the same or similar position.
 
 ### Nonpermanent Appointment Based on VRA Eligibility
-Agencies may make a noncompetitive temporary or term appointment based on an individual's eligibility for
-VRA appointment. The temporary or term appointment must be at the grades authorized for VRA
-appointment but is not a VRA appointment itself and does not lead to conversion to career-conditional.
+
+Agencies may make a noncompetitive temporary or term appointment based on an individual's eligibility for VRA appointment. The temporary or term appointment must be at the grades authorized for VRA appointment but is not a VRA appointment itself and does not lead to conversion to career-conditional.
+
 38 U.S.C. 4214; Pub. L. 107-288; 5 CFR Part 307; 5 CFR 752.401 (c)(3)
 
 ## 30 Percent or More Disabled Veterans
-An agency may give a noncompetitive temporary appointment of more than 60 days or a term appointment
-to any veteran:
+
+An agency may give a noncompetitive temporary appointment of more than 60 days or a term appointment to any veteran:
 * retired from active military service with a disability rating of 30 percent or more; or
-* rated by the Department of Veterans Affairs (VA) since 1991 or later to include disability
-determinations from a branch of the Armed Forces at any time, as having a compensable serviceconnected disability of 30 percent or more.
-There is no grade level limitation for this authority, but the appointee must meet all qualification
-requirements, including any written test requirement.
-The agency may convert the employee, without a break in service, to a career or career-conditional
-appointment at any time during the employee's temporary or term appointment.
+* rated by the Department of Veterans Affairs (VA) since 1991 or later to include disability determinations from a branch of the Armed Forces at any time, as having a compensable serviceconnected disability of 30 percent or more.
+
+There is no grade level limitation for this authority, but the appointee must meet all qualification requirements, including any written test requirement.
+
+The agency may convert the employee, without a break in service, to a career or career-conditional appointment at any time during the employee's temporary or term appointment.
+
 5 U.S.C. 3112; 5 CFR 316.302, 316.402 and 315.707
 
 ## Disabled Veterans Enrolled in a VA Training Program
-Disabled veterans eligible for training under the VA vocational rehabilitation program may enroll for
-training or work experience at an agency under the terms of an agreement between the agency and VA.
-While enrolled in the VA program, the veteran is not a Federal employee for most purposes but is a
-beneficiary of the VA.
-Training is tailored to the individual's needs and goals, so there is no set length. If the training is intended to
-prepare the individual for eventual appointment in the agency rather than just provide work experience,
-the agency must ensure that the training will enable the veteran to meet the qualification requirements for
-the position.
-Upon successful completion, the host agency and VA give the veteran a Certificate of Training showing the
-occupational series and grade level of the position for which trained. The Certificate of Training allows any
-agency to appoint the veteran noncompetitively under a status quo appointment which may be converted to
-career or career-conditional at any time.
+
+Disabled veterans eligible for training under the VA vocational rehabilitation program may enroll for training or work experience at an agency under the terms of an agreement between the agency and VA. While enrolled in the VA program, the veteran is not a Federal employee for most purposes but is a beneficiary of the VA.
+
+Training is tailored to the individual's needs and goals, so there is no set length. If the training is intended to prepare the individual for eventual appointment in the agency rather than just provide work experience, the agency must ensure that the training will enable the veteran to meet the qualification requirements for the position.
+
+Upon successful completion, the host agency and VA give the veteran a Certificate of Training showing the occupational series and grade level of the position for which trained. The Certificate of Training allows any agency to appoint the veteran noncompetitively under a status quo appointment which may be converted to career or career-conditional at any time.
+
 38 U.S.C. chapter 31; 5 CFR 3.1 and 315.604
 
 ## Veterans Employment Opportunities Act of 1998 (VEOA)
-The Veterans Employment Opportunities Act (VEOA) of 1998 as amended by Section 511 of the Veterans
-Millennium Health Care Act (Pub. Law 106-117) of November 30, 1999, provides that agencies must allow
-preference eligibles or eligible veterans to apply for positions announced under merit promotion procedures
-when the agency is recruiting from outside its own workforce. ("Agency," in this context, means the parent
-agency, i.e., Treasury, not the Internal Revenue Service and the Department of Defense, not Department of
-the Army.) A VEOA eligible who competes under merit promotion procedures and is selected will be given a
-career or career conditional appointment. Veterans' preference is not a factor in these appointments.
+
+The Veterans Employment Opportunities Act (VEOA) of 1998 as amended by Section 511 of the Veterans Millennium Health Care Act (Pub. Law 106-117) of November 30, 1999, provides that agencies must allow preference eligibles or eligible veterans to apply for positions announced under merit promotion procedures when the agency is recruiting from outside its own workforce. ("Agency," in this context, means the parent agency, i.e., Treasury, not the Internal Revenue Service and the Department of Defense, not Department of the Army.) A VEOA eligible who competes under merit promotion procedures and is selected will be given a career or career conditional appointment. Veterans' preference is not a factor in these appointments.
 
 ### Eligibility Requirements
+
 To be eligible for a VEOA appointment, an applicant must:
-* Be a preference eligible OR veteran separated from the armed forces after 3 or more years of
-continuous active service performed under honorable conditions. Veterans who were released shortly
-before completing a 3-year tour are considered to be eligible. ("Active service" defined in title 37,
-United States Code, means active duty in the uniformed services and includes full-time training duty,
-annual training duty, full-time National Guard duty, and attendance, while in the active service, at a
-school designated as a service school by law or by the Secretary of the military department concerned).
+* Be a preference eligible OR veteran separated from the armed forces after 3 or more years of continuous active service performed under honorable conditions. Veterans who were released shortly before completing a 3-year tour are considered to be eligible. ("Active service" defined in title 37, United States Code, means active duty in the uniformed services and includes full-time training duty, annual training duty, full-time National Guard duty, and attendance, while in the active service, at a school designated as a service school by law or by the Secretary of the military department concerned).
 
 ### Terms and Conditions of Employment
-Veterans who were appointed before the 1999 amendments to the VEOA were given Schedule B
-appointments in the excepted service. Those veterans who actually competed under merit promotion
-procedures will be converted to career conditional appointments retroactive to the date of their original
-VEOA appointments. Those who did not compete and were appointed noncompetitively will remain under
-Schedule B until they do compete. While under Schedule B, these employees may be promoted, demoted, or
-reassigned at their agency's discretion and may compete for jobs (whether in their own or other agencies)
-under the terms and conditions of the VEOA authority -- i.e., they may apply when the agency has issued a
-merit promotion announcement open to candidates outside the agency. If selected, they, too, will be given
-career conditional appointments.
-All employees appointed under the VEOA are subject to a probationary period and to the requirements of
-their agency's merit promotion plan.
-Agencies should use ZBA-Pub. L. 106-117, Sec 511 as the legal authority for any new appointments under the
-VEOA. This new authority code is effective December 1, 1999, and may be used with nature of action codes
-100, 101, 500, and 501.
+
+Veterans who were appointed before the 1999 amendments to the VEOA were given Schedule B appointments in the excepted service. Those veterans who actually competed under merit promotion procedures will be converted to career conditional appointments retroactive to the date of their original VEOA appointments. Those who did not compete and were appointed noncompetitively will remain under Schedule B until they do compete. While under Schedule B, these employees may be promoted, demoted, or reassigned at their agency's discretion and may compete for jobs (whether in their own or other agencies) under the terms and conditions of the VEOA authority -- i.e., they may apply when the agency has issued a merit promotion announcement open to candidates outside the agency. If selected, they, too, will be given career conditional appointments.
+
+All employees appointed under the VEOA are subject to a probationary period and to the requirements of their agency's merit promotion plan.
+
+Agencies should use ZBA-Pub. L. 106-117, Sec 511 as the legal authority for any new appointments under the VEOA. This new authority code is effective December 1, 1999, and may be used with nature of action codes 100, 101, 500, and 501.
 
 ### Appeal Rights
-Employees who are appointed in the competitive service have the appeal rights of competitive service
-employees. Those under Schedule B have the appeal rights of excepted service employees.
+
+Employees who are appointed in the competitive service have the appeal rights of competitive service employees. Those under Schedule B have the appeal rights of excepted service employees.
 
 ### A Word About VEOA
-The VEOA gives preference eligibles or veterans access and opportunity to apply for positions for which the
-agency is accepting applications beyond its own workforce under merit promotion procedures. Access and
-opportunity are not an entitlement to the position and it is not a guarantee for selection.
-Agencies announcing a position outside their workforces have three options for posting their vacancy
-announcements. Agencies can:
-Post a merit promotion "internal" vacancy announcement. When posting a merit promotion
-announcement, the agency must include information concerning consideration under the VEOA. This option
-meets the intent of the law that allows preference eligibles or veterans to compete with "status" candidates
-for these vacancies announced under merit promotion procedures.
-VEOA eligibles are rated and ranked with other merit promotion candidates under the same assessment
-criteria such as a crediting plan; however, veterans' preference is not applied. The appointing official may
-select any candidate from those who are among the best qualified. If selected, the VEOA eligible is given a
-career or career-conditional appointment, as appropriate.
-Post a Delegated Examining Unit (DEU) "external" vacancy announcement for "all sources."
-By posting the announcement as "all sources," that the VEOA eligible is treated in the same manner as any
-other applicant. If the VEOA eligible is qualified and within reach for referral, he or she is referred on the
-DEU list of eligibles.
-With an "all sources" announcement, most agencies consider applicants under a variety of other appointing
-authorities, such as, merit promotion, Veterans' Recruitment Appointment (VRA) or Schedule A of the
-excepted service. If the agency chooses to consider VEOA eligibles with the merit promotion candidates, the
-agency must include specific application instructions for the VEOA eligible in the vacancy announcement
-that are consistent with the agency's policies and procedures for accepting and processing applications.
-* Post two separate vacancy announcements - DEU and merit promotion. The VEOA eligible
-may apply for both announcements since the agency posted the vacancy announcements separately.
-The VEOA eligible is given two opportunities to be considered for one position and must be referred
-and considered on both lists, if eligible under the applicable procedures. The agency cannot remove
-the VEOA eligible from either list to make a selection. This means the agency may not deny
-consideration under one referral, e.g., DEU, because the VEOA eligible is being considered under a
-different referral, e.g., merit promotion.
+
+The VEOA gives preference eligibles or veterans access and opportunity to apply for positions for which the agency is accepting applications beyond its own workforce under merit promotion procedures. Access and opportunity are not an entitlement to the position and it is not a guarantee for selection.
+
+Agencies announcing a position outside their workforces have three options for posting their vacancy announcements. Agencies can:
+
+Post a merit promotion "internal" vacancy announcement. When posting a merit promotion announcement, the agency must include information concerning consideration under the VEOA. This option meets the intent of the law that allows preference eligibles or veterans to compete with "status" candidates for these vacancies announced under merit promotion procedures.
+
+VEOA eligibles are rated and ranked with other merit promotion candidates under the same assessment criteria such as a crediting plan; however, veterans' preference is not applied. The appointing official may select any candidate from those who are among the best qualified. If selected, the VEOA eligible is given a career or career-conditional appointment, as appropriate.
+
+Post a Delegated Examining Unit (DEU) "external" vacancy announcement for "all sources." By posting the announcement as "all sources," that the VEOA eligible is treated in the same manner as any other applicant. If the VEOA eligible is qualified and within reach for referral, he or she is referred on the DEU list of eligibles.
+
+With an "all sources" announcement, most agencies consider applicants under a variety of other appointing authorities, such as, merit promotion, Veterans' Recruitment Appointment (VRA) or Schedule A of the excepted service. If the agency chooses to consider VEOA eligibles with the merit promotion candidates, the agency must include specific application instructions for the VEOA eligible in the vacancy announcement that are consistent with the agency's policies and procedures for accepting and processing applications.
+
+* Post two separate vacancy announcements - DEU and merit promotion. The VEOA eligible may apply for both announcements since the agency posted the vacancy announcements separately. The VEOA eligible is given two opportunities to be considered for one position and must be referred and considered on both lists, if eligible under the applicable procedures. The agency cannot remove the VEOA eligible from either list to make a selection. This means the agency may not deny consideration under one referral, e.g., DEU, because the VEOA eligible is being considered under a different referral, e.g., merit promotion.
 
 ### Questions and Answers
-* Do the amendments made by Pub. L. 106-117 mean that agencies may no longer use
-authority code YKB/SchB 213.3202(n) to appoint eligible veterans under the Veterans
-Employment Opportunities Act of 1998 (VEOA)?
-As of the date of enactment of the new amendments (November 30, 1999), agencies should not make
-any new appointments under the Schedule B authority. However, we are allowing a 1-month grace
-period to cover any appointments under the Schedule B authority that may already have been in
-progress.
-* If VEOA-eligible veterans should no longer be appointed under the above Schedule B
-authority, how are they appointed?
-The law provides that preference eligibles or eligible veterans who compete under agency Merit
-Promotion procedures open to candidates outside the agency ("agency" in this context means the
-parent agency such as Treasury, not IRS), and who are selected from among the best qualified, shall
-receive a career or career conditional appointment, as appropriate. Agencies should use the authority
-ZBA-Pub.L. 106-117, Sec 511 for these appointments.
-* What happens to veterans who were appointed under Schedule B?
-Agencies should first determine whether their Schedule B appointees actually competed under Merit
-Promotion procedures or were selected noncompetitively as a separate source of eligibles.
-Those veterans who competed under agency Merit Promotion procedures are to be converted to career
-conditional (or career) retroactive to the date of their original appointments. These individuals will
-have been serving probation as of the original date of their appointments and this must be made clear
-to the employees.
-Those veterans who did not compete under an agency Merit Promotion announcement and were given
-a Schedule B appointment noncompetitively, remain under Schedule B until such time as they can be
-appointed based on competition ? either under Merit Promotion procedures open to candidates
-outside the agency or through an open competitive announcement. Because an employee may remain
-under the Schedule B authority until such time as he or she is selected competitively, we are leaving
-the authority in place indefinitely; he or she may not be required to compete for a career conditional position.
-* Did the new amendments change the eligibility criteria for appointment under the
-VEOA?
-Yes. Prior to these amendments, a veteran had to be either a preference eligible or have at least 3 years
-of continuous active duty military service in order to qualify for appointment under the VEOA. The
-new amendments provide that OPM is authorized to regulate the circumstances under which
-individuals who were released from active duty "shortly before completing 3 years of active duty" may
-be appointed. In our interim regulations implementing this provision, we are proposing to use the
-term "substantially completed an initial 3-year term." Agencies will then decide, in individual cases,
-whether a candidate has met this standard. In general, most individuals completing an initial 3-year
-military tour are typically released a few days early. These individuals, if otherwise qualified, should be
-considered eligible.
-* Does Veterans' preference apply to appointments under the VEOA?
-No. Veterans preference does not apply to merit promotion actions.
-* Are eligible veterans permitted to apply for vacancies that are open to CTAP candidates
-only?
-No. Since CTAP is limited to internal agency candidates, VEOA eligibles may not apply.
-* Are eligible veterans permitted to apply for vacancies that are open to ICTAP candidates
-only?
-Yes. Since ICTAP is open to candidates outside the agency, the law requires that VEOA eligibles be
-allowed to apply.
-* Do VEOA appointees serve a probationary period?
-Yes. Since they are appointed in the competitive service, they are subject to a probationary period.
-Please note, however, that for those employees converted from the Schedule B authority, prior service
-counts towards completion of probation provided it is in the same agency, same line of work, and
-without a break in service. Where applicable, agencies must inform individuals that their original
-appointment under the VEOA authority marked the beginning of a probationary period.
-* Can VEOA candidates be considered for temporary and term positions?
-No. Because VEOA mandates that eligible veterans be given career or career conditional
-appointments, temporary or term appointments cannot be offered.
-* Can a current career/career conditional employee who lacks time-in-grade apply as a
-VEOA candidate under an agency merit promotion announcement?
-No. Such an employee remains subject to time-in-grade restrictions. The VEOA is not a
-noncompetitive-entry authority like the VRA where an employee could be given a new appointment at
-a higher grade.
-* Can a current career/career conditional employee who meets time-in-grade and
-eligibility requirements apply as a VEOA candidate under an agency merit promotion
-announcement and, if selected, be given a new career/career conditional appointment
-using the VEOA appointing authority?
-Yes. Currently, a career/career conditional employee who meets time-in-grade and eligibility
-requirements would be able to apply directly to a merit promotion announcement without the need to
-use the VEOA authority. However, under the plain language of the VEOA, the law would allow current
-career/career conditional Federal employees who are preference eligibles or veterans meeting the
-eligibility criteria of the vacancy announcement to apply to those positions advertised under an
-agency's merit promotion procedures when seeking candidates from outside its own workforce. The
-term preference eligibles is defined in title 5, United States Code section 2108.
-* Can a current career/career conditional employee who meets time-in-grade and
-eligibility requirements apply as a VEOA candidate under an agency merit promotion
-announcement when he or she is outside the stated area of consideration?
-Yes. A career/career conditional employee who meets time-in-grade and eligibility requirements
-would be able to apply using VEOA to a merit promotion announcement when outside the stated area
-of consideration.
-* Can a preference eligible or eligible veteran who is outside the agency merit promotion
-announcement's area of consideration apply as a VEOA candidate?
-Yes. A preference eligible or eligible veteran would be able to apply using VEOA to a merit promotion
-announcement even though he or she is outside the vacancy announcement's area of consideration.
-* We understand that VEOA eligibles are expected to compete with agency merit
-promotion eligibles under the agency's merit promotion plan. But, is the agency
-expected to create a different crediting plan for considering VEOA candidates?
-No. VEOA candidates are considered along with agency candidates, and under the same crediting
-plan.
-* To be eligible for an appointment under the VEOA authority, a veteran must be
-"separated" from the service. Does this mean that he or she cannot apply and be
-considered until actually separated?
-No. Whether or not to consider someone who is still in the military is entirely at the discretion of the
-employing agency. By law, a person on military duty cannot be appointed to a civilian position (unless
-on terminal leave), but he or she can certainly be considered should the agency wish to do so. The
-determining factor, here, should be whether the person will be available when the agency needs to
-have the job filled.
-5 U.S.C. 3304, 3330; 5 CFR 213.3202 (n) and 335.106
 
-Based on the OPM Vet Guide for HR Professionals (Chapter: Special Appointing Authorities for Veterans).
+**Do the amendments made by Pub. L. 106-117 mean that agencies may no longer use authority code YKB/SchB 213.3202(n) to appoint eligible veterans under the Veterans Employment Opportunities Act of 1998 (VEOA)?**
+
+As of the date of enactment of the new amendments (November 30, 1999), agencies should not make any new appointments under the Schedule B authority. However, we are allowing a 1-month grace period to cover any appointments under the Schedule B authority that may already have been in progress.
+
+**If VEOA-eligible veterans should no longer be appointed under the above Schedule B authority, how are they appointed?**
+
+The law provides that preference eligibles or eligible veterans who compete under agency Merit Promotion procedures open to candidates outside the agency ("agency" in this context means the parent agency such as Treasury, not IRS), and who are selected from among the best qualified, shall receive a career or career conditional appointment, as appropriate. Agencies should use the authority ZBA-Pub.L. 106-117, Sec 511 for these appointments.
+
+**What happens to veterans who were appointed under Schedule B?**
+
+Agencies should first determine whether their Schedule B appointees actually competed under Merit Promotion procedures or were selected noncompetitively as a separate source of eligibles.
+
+Those veterans who competed under agency Merit Promotion procedures are to be converted to career conditional (or career) retroactive to the date of their original appointments. These individuals will have been serving probation as of the original date of their appointments and this must be made clear to the employees.
+
+Those veterans who did not compete under an agency Merit Promotion announcement and were given a Schedule B appointment noncompetitively, remain under Schedule B until such time as they can be appointed based on competition ? either under Merit Promotion procedures open to candidates outside the agency or through an open competitive announcement. Because an employee may remain under the Schedule B authority until such time as he or she is selected competitively, we are leaving the authority in place indefinitely; he or she may not be required to compete for a career conditional position.
+
+**Did the new amendments change the eligibility criteria for appointment under the VEOA?**
+
+Yes. Prior to these amendments, a veteran had to be either a preference eligible or have at least 3 years of continuous active duty military service in order to qualify for appointment under the VEOA. The new amendments provide that OPM is authorized to regulate the circumstances under which individuals who were released from active duty "shortly before completing 3 years of active duty" may be appointed. In our interim regulations implementing this provision, we are proposing to use the term "substantially completed an initial 3-year term." Agencies will then decide, in individual cases, whether a candidate has met this standard. In general, most individuals completing an initial 3-year military tour are typically released a few days early. These individuals, if otherwise qualified, should be considered eligible.
+
+**Does Veterans' preference apply to appointments under the VEOA?**
+
+No. Veterans preference does not apply to merit promotion actions.
+
+**Are eligible veterans permitted to apply for vacancies that are open to CTAP candidates only?**
+
+No. Since CTAP is limited to internal agency candidates, VEOA eligibles may not apply.
+
+**Are eligible veterans permitted to apply for vacancies that are open to ICTAP candidates only?**
+
+Yes. Since ICTAP is open to candidates outside the agency, the law requires that VEOA eligibles be allowed to apply.
+
+**Do VEOA appointees serve a probationary period?**
+
+Yes. Since they are appointed in the competitive service, they are subject to a probationary period. Please note, however, that for those employees converted from the Schedule B authority, prior service counts towards completion of probation provided it is in the same agency, same line of work, and without a break in service. Where applicable, agencies must inform individuals that their original appointment under the VEOA authority marked the beginning of a probationary period.
+
+**Can VEOA candidates be considered for temporary and term positions?**
+
+No. Because VEOA mandates that eligible veterans be given career or career conditional appointments, temporary or term appointments cannot be offered.
+
+**Can a current career/career conditional employee who lacks time-in-grade apply as a VEOA candidate under an agency merit promotion announcement?**
+
+No. Such an employee remains subject to time-in-grade restrictions. The VEOA is not a noncompetitive-entry authority like the VRA where an employee could be given a new appointment at a higher grade.
+
+**Can a current career/career conditional employee who meets time-in-grade and eligibility requirements apply as a VEOA candidate under an agency merit promotion announcement and, if selected, be given a new career/career conditional appointment using the VEOA appointing authority?**
+
+Yes. Currently, a career/career conditional employee who meets time-in-grade and eligibility requirements would be able to apply directly to a merit promotion announcement without the need to use the VEOA authority. However, under the plain language of the VEOA, the law would allow current career/career conditional Federal employees who are preference eligibles or veterans meeting the eligibility criteria of the vacancy announcement to apply to those positions advertised under an agency's merit promotion procedures when seeking candidates from outside its own workforce. The term preference eligibles is defined in title 5, United States Code section 2108.
+
+**Can a current career/career conditional employee who meets time-in-grade and eligibility requirements apply as a VEOA candidate under an agency merit promotion announcement when he or she is outside the stated area of consideration?**
+
+Yes. A career/career conditional employee who meets time-in-grade and eligibility requirements would be able to apply using VEOA to a merit promotion announcement when outside the stated area of consideration.
+
+**Can a preference eligible or eligible veteran who is outside the agency merit promotion announcement's area of consideration apply as a VEOA candidate?**
+
+Yes. A preference eligible or eligible veteran would be able to apply using VEOA to a merit promotion announcement even though he or she is outside the vacancy announcement's area of consideration.
+
+**We understand that VEOA eligibles are expected to compete with agency merit promotion eligibles under the agency's merit promotion plan. But, is the agency expected to create a different crediting plan for considering VEOA candidates?**
+
+No. VEOA candidates are considered along with agency candidates, and under the same crediting plan.
+
+**To be eligible for an appointment under the VEOA authority, a veteran must be "separated" from the service. Does this mean that he or she cannot apply and be considered until actually separated?**
+
+No. Whether or not to consider someone who is still in the military is entirely at the discretion of the employing agency. By law, a person on military duty cannot be appointed to a civilian position (unless on terminal leave), but he or she can certainly be considered should the agency wish to do so. The determining factor, here, should be whether the person will be available when the agency needs to have the job filled.
+
+5 U.S.C. 3304, 3330; 5 CFR 213.3202 (n) and 335.106

--- a/special_authorities_content.txt
+++ b/special_authorities_content.txt
@@ -1,0 +1,269 @@
+Special Appointing Authorities for Veterans
+
+Veterans Recruitment Appointment (VRA) Authority
+The VRA is a special authority by which agencies can, if they wish, appoint eligible veterans without
+competition to positions at any grade level through General Schedule (GS) 11 or equivalent. (The promotion
+potential of the position is not a factor.) VRA appointees are hired under excepted appointments to positions
+that are otherwise in the competitive service. There is no limitation to the number of VRA appointments an
+individual may receive, provided the individual is otherwise eligible.
+If the agency has more than one VRA candidate for the same job and one (or more) is a preference eligible,
+the agency must apply the Veterans' preference procedures prescribed in 5 CFR Part 302 in making VRA
+appointments. A veteran who is eligible for a VRA appointment is not automatically eligible for Veterans'
+preference.
+After two years of satisfactory service, the agency must convert the veteran to career or career-conditional
+appointment, as appropriate.
+
+Eligibility Criteria:
+The Jobs for Veterans Act, Public Law 107-288, amended title 38 U.S.C. 4214 by making a major change in
+the eligibility criteria for obtaining a Veterans Recruitment Appointment (VRA). Those who are eligible:
+* Disabled veterans; or
+* Veterans who served on active duty in the Armed Forces during a war, or in a campaign or expedition
+for which a campaign badge has been authorized; or
+* Veterans who, while serving on active duty in the Armed Forces, participated in a United States
+military operation for which an Armed Forces Service Medal was awarded; or
+* Recently separated veterans.
+Veterans claiming eligibility on the basis of service in a campaign or expedition for which a medal was
+awarded must be in receipt of the campaign badge or medal.
+In addition to meeting the criteria above, eligible veterans must have been separated under honorable
+conditions (i.e., the individual must have received either an honorable or general discharge).
+Note: Under the eligibility criteria, not all 5-point preference eligible veterans may be eligible for a VRA
+appointment. For example, a veteran who served during the Vietnam era (i.e., for more than 180 consecutive
+days, after January 31, 1955, and before October 15, 1976) but did not receive a service-connected disability
+or an Armed Forces Service medal or campaign or expeditionary medal would be entitled to 5 pt. veterans'
+preference. This veteran, however, would not be eligible for a VRA appointment under the above criteria.
+As another example, a veteran who served during the Gulf War from August 2, 1990, through January 2,
+1992, would be eligible for veterans' preference solely on the basis of that service. However, service during
+that time period, in and of itself, does not confer VRA eligibility on the veteran unless one of the above VRA
+eligibility criteria is met.
+Lastly, if an agency has 2 or more VRA candidates and 1 or more is a preference eligible, the agency must
+apply Veterans' preference. For example, one applicant is VRA eligible on the basis of receiving an Armed
+Forces Service Medal (this medal does not confer veterans' preference eligibility). The second applicant is
+VRA eligible on the basis of being a disabled veteran (which does confer veterans' preference eligibility). In
+this example, both individuals are VRA eligible but only one of them is eligible for Veterans' preference. As a
+result, agencies must apply the procedures of 5 CFR 302 when considering VRA candidates for appointment.
+
+Making Appointments
+Ordinarily, an agency may simply appoint any VRA eligible who meets the basic qualifications requirements
+for the position to be filled without having to announce the job or rate and rank applicants. However, as
+noted, Veterans' preference applies in making appointments under the VRA authority. This means that if an
+agency has 2 or more VRA candidates and 1 or more is a preference eligible, the agency must apply Veterans'
+preference. Furthermore, an agency must consider all VRA candidates on file who are qualified for the
+position and could reasonably expect to be considered for the opportunity; it cannot place VRA candidates in
+separate groups or consider them as separate sources in order to avoid applying preference or to reach a
+favored candidate.
+
+Terms and Conditions of Employment
+A VRA appointee may be promoted, demoted, reassigned, or transferred in the same way as a career
+employee. As with other competitive service employees, the time in grade requirement applies to the
+promotion of VRAs. If a VRA-eligible employee is qualified for a higher grade, an agency may, at its
+discretion, give the employee a new VRA appointment at a higher grade up through GS-11 (or equivalent)
+without regard to time-in-grade.
+Agencies must establish a training or education program for any VRA appointee who has less than 15 years
+of education. This program should meet the needs of both the agency and the employee.
+
+Appeal Rights
+During their first year of employment, VRA appointees have the same limited appeal rights as competitive
+service probationers, but otherwise they have the appeal rights of excepted service employees. This means
+that VRA employees who are preference eligibles have adverse action protections after one year (see Chapter
+7). VRA's who are not preference eligibles do not get this protection until they have completed 2 years of
+current continuous employment in the same or similar position.
+
+Nonpermanent Appointment Based on VRA Eligibility
+Agencies may make a noncompetitive temporary or term appointment based on an individual's eligibility for
+VRA appointment. The temporary or term appointment must be at the grades authorized for VRA
+appointment but is not a VRA appointment itself and does not lead to conversion to career-conditional.
+38 U.S.C. 4214; Pub. L. 107-288; 5 CFR Part 307; 5 CFR 752.401 (c)(3)
+
+30 Percent or More Disabled Veterans
+An agency may give a noncompetitive temporary appointment of more than 60 days or a term appointment
+to any veteran:
+* retired from active military service with a disability rating of 30 percent or more; or
+* rated by the Department of Veterans Affairs (VA) since 1991 or later to include disability
+determinations from a branch of the Armed Forces at any time, as having a compensable serviceconnected disability of 30 percent or more.
+There is no grade level limitation for this authority, but the appointee must meet all qualification
+requirements, including any written test requirement.
+The agency may convert the employee, without a break in service, to a career or career-conditional
+appointment at any time during the employee's temporary or term appointment.
+5 U.S.C. 3112; 5 CFR 316.302, 316.402 and 315.707
+
+Disabled Veterans Enrolled in a VA Training Program
+Disabled veterans eligible for training under the VA vocational rehabilitation program may enroll for
+training or work experience at an agency under the terms of an agreement between the agency and VA.
+While enrolled in the VA program, the veteran is not a Federal employee for most purposes but is a
+beneficiary of the VA.
+Training is tailored to the individual's needs and goals, so there is no set length. If the training is intended to
+prepare the individual for eventual appointment in the agency rather than just provide work experience,
+the agency must ensure that the training will enable the veteran to meet the qualification requirements for
+the position.
+Upon successful completion, the host agency and VA give the veteran a Certificate of Training showing the
+occupational series and grade level of the position for which trained. The Certificate of Training allows any
+agency to appoint the veteran noncompetitively under a status quo appointment which may be converted to
+career or career-conditional at any time.
+38 U.S.C. chapter 31; 5 CFR 3.1 and 315.604
+
+Veterans Employment Opportunities Act of 1998 (VEOA)
+The Veterans Employment Opportunities Act (VEOA) of 1998 as amended by Section 511 of the Veterans
+Millennium Health Care Act (Pub. Law 106-117) of November 30, 1999, provides that agencies must allow
+preference eligibles or eligible veterans to apply for positions announced under merit promotion procedures
+when the agency is recruiting from outside its own workforce. ("Agency," in this context, means the parent
+agency, i.e., Treasury, not the Internal Revenue Service and the Department of Defense, not Department of
+the Army.) A VEOA eligible who competes under merit promotion procedures and is selected will be given a
+career or career conditional appointment. Veterans' preference is not a factor in these appointments.
+
+Eligibility Requirements
+To be eligible for a VEOA appointment, an applicant must:
+* Be a preference eligible OR veteran separated from the armed forces after 3 or more years of
+continuous active service performed under honorable conditions. Veterans who were released shortly
+before completing a 3-year tour are considered to be eligible. ("Active service" defined in title 37,
+United States Code, means active duty in the uniformed services and includes full-time training duty,
+annual training duty, full-time National Guard duty, and attendance, while in the active service, at a
+school designated as a service school by law or by the Secretary of the military department concerned).
+
+Terms and Conditions of Employment
+Veterans who were appointed before the 1999 amendments to the VEOA were given Schedule B
+appointments in the excepted service. Those veterans who actually competed under merit promotion
+procedures will be converted to career conditional appointments retroactive to the date of their original
+VEOA appointments. Those who did not compete and were appointed noncompetitively will remain under
+Schedule B until they do compete. While under Schedule B, these employees may be promoted, demoted, or
+reassigned at their agency's discretion and may compete for jobs (whether in their own or other agencies)
+under the terms and conditions of the VEOA authority -- i.e., they may apply when the agency has issued a
+merit promotion announcement open to candidates outside the agency. If selected, they, too, will be given
+career conditional appointments.
+All employees appointed under the VEOA are subject to a probationary period and to the requirements of
+their agency's merit promotion plan.
+Agencies should use ZBA-Pub. L. 106-117, Sec 511 as the legal authority for any new appointments under the
+VEOA. This new authority code is effective December 1, 1999, and may be used with nature of action codes
+100, 101, 500, and 501.
+
+Appeal Rights
+Employees who are appointed in the competitive service have the appeal rights of competitive service
+employees. Those under Schedule B have the appeal rights of excepted service employees.
+
+A Word About VEOA
+The VEOA gives preference eligibles or veterans access and opportunity to apply for positions for which the
+agency is accepting applications beyond its own workforce under merit promotion procedures. Access and
+opportunity are not an entitlement to the position and it is not a guarantee for selection.
+Agencies announcing a position outside their workforces have three options for posting their vacancy
+announcements. Agencies can:
+Post a merit promotion "internal" vacancy announcement. When posting a merit promotion
+announcement, the agency must include information concerning consideration under the VEOA. This option
+meets the intent of the law that allows preference eligibles or veterans to compete with "status" candidates
+for these vacancies announced under merit promotion procedures.
+VEOA eligibles are rated and ranked with other merit promotion candidates under the same assessment
+criteria such as a crediting plan; however, veterans' preference is not applied. The appointing official may
+select any candidate from those who are among the best qualified. If selected, the VEOA eligible is given a
+career or career-conditional appointment, as appropriate.
+Post a Delegated Examining Unit (DEU) "external" vacancy announcement for "all sources."
+By posting the announcement as "all sources," that the VEOA eligible is treated in the same manner as any
+other applicant. If the VEOA eligible is qualified and within reach for referral, he or she is referred on the
+DEU list of eligibles.
+With an "all sources" announcement, most agencies consider applicants under a variety of other appointing
+authorities, such as, merit promotion, Veterans' Recruitment Appointment (VRA) or Schedule A of the
+excepted service. If the agency chooses to consider VEOA eligibles with the merit promotion candidates, the
+agency must include specific application instructions for the VEOA eligible in the vacancy announcement
+that are consistent with the agency's policies and procedures for accepting and processing applications.
+* Post two separate vacancy announcements - DEU and merit promotion. The VEOA eligible
+may apply for both announcements since the agency posted the vacancy announcements separately.
+The VEOA eligible is given two opportunities to be considered for one position and must be referred
+and considered on both lists, if eligible under the applicable procedures. The agency cannot remove
+the VEOA eligible from either list to make a selection. This means the agency may not deny
+consideration under one referral, e.g., DEU, because the VEOA eligible is being considered under a
+different referral, e.g., merit promotion.
+
+Questions and Answers
+* Do the amendments made by Pub. L. 106-117 mean that agencies may no longer use
+authority code YKB/SchB 213.3202(n) to appoint eligible veterans under the Veterans
+Employment Opportunities Act of 1998 (VEOA)?
+As of the date of enactment of the new amendments (November 30, 1999), agencies should not make
+any new appointments under the Schedule B authority. However, we are allowing a 1-month grace
+period to cover any appointments under the Schedule B authority that may already have been in
+progress.
+* If VEOA-eligible veterans should no longer be appointed under the above Schedule B
+authority, how are they appointed?
+The law provides that preference eligibles or eligible veterans who compete under agency Merit
+Promotion procedures open to candidates outside the agency ("agency" in this context means the
+parent agency such as Treasury, not IRS), and who are selected from among the best qualified, shall
+receive a career or career conditional appointment, as appropriate. Agencies should use the authority
+ZBA-Pub.L. 106-117, Sec 511 for these appointments.
+* What happens to veterans who were appointed under Schedule B?
+Agencies should first determine whether their Schedule B appointees actually competed under Merit
+Promotion procedures or were selected noncompetitively as a separate source of eligibles.
+Those veterans who competed under agency Merit Promotion procedures are to be converted to career
+conditional (or career) retroactive to the date of their original appointments. These individuals will
+have been serving probation as of the original date of their appointments and this must be made clear
+to the employees.
+Those veterans who did not compete under an agency Merit Promotion announcement and were given
+a Schedule B appointment noncompetitively, remain under Schedule B until such time as they can be
+appointed based on competition ? either under Merit Promotion procedures open to candidates
+outside the agency or through an open competitive announcement. Because an employee may remain
+under the Schedule B authority until such time as he or she is selected competitively, we are leaving
+the authority in place indefinitely; he or she may not be required to compete for a career conditional position.
+* Did the new amendments change the eligibility criteria for appointment under the
+VEOA?
+Yes. Prior to these amendments, a veteran had to be either a preference eligible or have at least 3 years
+of continuous active duty military service in order to qualify for appointment under the VEOA. The
+new amendments provide that OPM is authorized to regulate the circumstances under which
+individuals who were released from active duty "shortly before completing 3 years of active duty" may
+be appointed. In our interim regulations implementing this provision, we are proposing to use the
+term "substantially completed an initial 3-year term." Agencies will then decide, in individual cases,
+whether a candidate has met this standard. In general, most individuals completing an initial 3-year
+military tour are typically released a few days early. These individuals, if otherwise qualified, should be
+considered eligible.
+* Does Veterans' preference apply to appointments under the VEOA?
+No. Veterans preference does not apply to merit promotion actions.
+* Are eligible veterans permitted to apply for vacancies that are open to CTAP candidates
+only?
+No. Since CTAP is limited to internal agency candidates, VEOA eligibles may not apply.
+* Are eligible veterans permitted to apply for vacancies that are open to ICTAP candidates
+only?
+Yes. Since ICTAP is open to candidates outside the agency, the law requires that VEOA eligibles be
+allowed to apply.
+* Do VEOA appointees serve a probationary period?
+Yes. Since they are appointed in the competitive service, they are subject to a probationary period.
+Please note, however, that for those employees converted from the Schedule B authority, prior service
+counts towards completion of probation provided it is in the same agency, same line of work, and
+without a break in service. Where applicable, agencies must inform individuals that their original
+appointment under the VEOA authority marked the beginning of a probationary period.
+* Can VEOA candidates be considered for temporary and term positions?
+No. Because VEOA mandates that eligible veterans be given career or career conditional
+appointments, temporary or term appointments cannot be offered.
+* Can a current career/career conditional employee who lacks time-in-grade apply as a
+VEOA candidate under an agency merit promotion announcement?
+No. Such an employee remains subject to time-in-grade restrictions. The VEOA is not a
+noncompetitive-entry authority like the VRA where an employee could be given a new appointment at
+a higher grade.
+* Can a current career/career conditional employee who meets time-in-grade and
+eligibility requirements apply as a VEOA candidate under an agency merit promotion
+announcement and, if selected, be given a new career/career conditional appointment
+using the VEOA appointing authority?
+Yes. Currently, a career/career conditional employee who meets time-in-grade and eligibility
+requirements would be able to apply directly to a merit promotion announcement without the need to
+use the VEOA authority. However, under the plain language of the VEOA, the law would allow current
+career/career conditional Federal employees who are preference eligibles or veterans meeting the
+eligibility criteria of the vacancy announcement to apply to those positions advertised under an
+agency's merit promotion procedures when seeking candidates from outside its own workforce. The
+term preference eligibles is defined in title 5, United States Code section 2108.
+* Can a current career/career conditional employee who meets time-in-grade and
+eligibility requirements apply as a VEOA candidate under an agency merit promotion
+announcement when he or she is outside the stated area of consideration?
+Yes. A career/career conditional employee who meets time-in-grade and eligibility requirements
+would be able to apply using VEOA to a merit promotion announcement when outside the stated area
+of consideration.
+* Can a preference eligible or eligible veteran who is outside the agency merit promotion
+announcement's area of consideration apply as a VEOA candidate?
+Yes. A preference eligible or eligible veteran would be able to apply using VEOA to a merit promotion
+announcement even though he or she is outside the vacancy announcement's area of consideration.
+* We understand that VEOA eligibles are expected to compete with agency merit
+promotion eligibles under the agency's merit promotion plan. But, is the agency
+expected to create a different crediting plan for considering VEOA candidates?
+No. VEOA candidates are considered along with agency candidates, and under the same crediting
+plan.
+* To be eligible for an appointment under the VEOA authority, a veteran must be
+"separated" from the service. Does this mean that he or she cannot apply and be
+considered until actually separated?
+No. Whether or not to consider someone who is still in the military is entirely at the discretion of the
+employing agency. By law, a person on military duty cannot be appointed to a civilian position (unless
+on terminal leave), but he or she can certainly be considered should the agency wish to do so. The
+determining factor, here, should be whether the person will be available when the agency needs to
+have the job filled.
+5 U.S.C. 3304, 3330; 5 CFR 213.3202 (n) and 335.106


### PR DESCRIPTION
This commit addresses Phase 2 of the content integration. The following Markdown files have been populated with content extracted from hrdocs.txt:

- eligibility.md
- preference-types.md
- rif-procedures.md
- special-authorities.md
- faq.md

Each file now contains the relevant sections from the source document, formatted with Jekyll front matter, Markdown headings, lists, and paragraphs.

The main navigation links in index.md were verified to correctly point to these new pages. No changes were required for the _includes/navigation.html based on the current scope.