### PR TITLE
Add source_citation to special-authorities.md

### DIFF
--- a/special-authorities.md
+++ b/special-authorities.md
@@ -2,6 +2,7 @@
 layout: page
 title: Special Appointing Authorities for Veterans
 permalink: /special-authorities/
+source_citation: "Content derived from hrdocs.txt, Chapter/Section on Special Appointing Authorities."
 ---
 
 ## Special Appointing Authorities for Veterans


### PR DESCRIPTION
This commit adds the `source_citation` field to the front matter of `special-authorities.md`.

The content of the file was already sourced from hrdocs.txt, this change simply documents that fact in the front matter as you requested.