### PR TITLE
Add collection_item.html layout

### DIFF
--- a/_layouts/collection_item.html
+++ b/_layouts/collection_item.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+<article>
+    {% include breadcrumb.html %}
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+    <aside class="citation">
+        <h3>Source Reference</h3>
+        <p>This information is based on hrdocs.txt, specifically the content identified as {{ page.appendix_letter | default: "the relevant appendix" }}.</p>
+    </aside>
+</article>


### PR DESCRIPTION
This commit introduces a new layout file, `_layouts/collection_item.html`, for rendering items within a Jekyll collection.

The layout includes:
- A breadcrumb navigation.
- The page title.
- The main content of the item.
- A citation section that references "hrdocs.txt" and uses `page.appendix_letter` or a default value.